### PR TITLE
Refactor connection and add auto retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Currently the following options are available:
 | Option | Description |
 | ------ | ----------- |
 | authToken | Auth token to use to validate with Home Assistant.
+| setupRetry | Number of times to retry initial connection when it fails. -1 means infinite.
 
 #### Possible error codes
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -5,20 +5,138 @@ import {
   ERR_CONNECTION_LOST,
 } from './const';
 
+function getSocket(url, options) {
+  if (__DEV__) {
+    /* eslint-disable no-console */
+    console.log('[Auth phase] Initializing', url);
+    /* eslint-enable no-console */
+  }
+
+  function connect(triesLeft, promResolve, promReject) {
+    if (__DEV__) {
+      /* eslint-disable no-console */
+      console.log('[Auth Phase] New connection', url);
+      /* eslint-enable no-console */
+    }
+
+    const socket = new WebSocket(url);
+
+    // If invalid auth, we will not try to reconnect.
+    let invalidAuth = false;
+
+    const closeMessage = () => {
+      if (invalidAuth) {
+        promReject(ERR_INVALID_AUTH);
+        return;
+      }
+
+      // Reject if we no longer have to retry
+      if (triesLeft === 0) {
+        // We never were connected and will not retry
+        promReject(ERR_CANNOT_CONNECT);
+        return;
+      }
+
+      const newTries = triesLeft === -1 ? -1 : triesLeft - 1;
+      // Try again in a second
+      setTimeout(() => connect(newTries, promResolve, promReject), 1000);
+    };
+
+    const handleMessage = (event) => {
+      const message = JSON.parse(event.data);
+
+      if (__DEV__) {
+        /* eslint-disable no-console */
+        console.log('[Auth phase] Received', message);
+        /* eslint-enable no-console */
+      }
+
+      switch (message.type) {
+        case 'auth_required':
+          if ('authToken' in options) {
+            socket.send(JSON.stringify(messages.auth(options.authToken)));
+          } else {
+            invalidAuth = true;
+            socket.close();
+          }
+          break;
+
+        case 'auth_invalid':
+          invalidAuth = true;
+          socket.close();
+          break;
+
+        case 'auth_ok':
+          socket.removeEventListener('message', handleMessage);
+          socket.removeEventListener('close', closeMessage);
+          promResolve(socket);
+          break;
+
+        default:
+          if (__DEV__) {
+            /* eslint-disable no-console */
+            console.warn('[Auth phase] Unhandled message', message);
+            /* eslint-enable no-console */
+          }
+      }
+    };
+
+    socket.addEventListener('message', handleMessage);
+    socket.addEventListener('close', closeMessage);
+  }
+
+  return new Promise((resolve, reject) => connect(options.setupRetry || 0, resolve, reject));
+}
+
 function extractResult(message) {
   return message.result;
 }
 
 class Connection {
   constructor(url, options) {
+    // websocket API url
     this.url = url;
+    // connection options
+    //  - authToken: auth to use
+    //  - setupRetry: amount of ms to retry when unable to connect on initial setup
     this.options = options || {};
+    // id if next command to send
     this.commandId = 1;
+    // info about active subscriptions and commands in flight
     this.commands = {};
-    this.connectionTries = 0;
+    // map of event listeners
     this.eventListeners = {};
+    // true if a close is requested by the user
     this.closeRequested = false;
-    this.firstConnection = true;
+
+    this._handleMessage = this._handleMessage.bind(this);
+    this._handleClose = this._handleClose.bind(this);
+  }
+
+  setSocket(socket) {
+    const oldSocket = this.socket;
+    this.socket = socket;
+    socket.addEventListener('message', this._handleMessage);
+    socket.addEventListener('close', this._handleClose);
+
+    if (oldSocket) {
+      const oldCommands = this.commands;
+
+      // reset to original state
+      this.commandId = 1;
+      this.commands = {};
+
+      Object.keys(oldCommands).forEach((id) => {
+        const info = oldCommands[id];
+
+        if (info.eventType) {
+          this.subscribeEvents(info.eventCallback, info.eventType)
+            .then((unsub) => { info.unsubscribe = unsub; });
+        }
+      });
+
+      this.fireEvent('ready');
+    }
   }
 
   addEventListener(eventType, callback) {
@@ -47,114 +165,6 @@ class Connection {
 
   fireEvent(eventType) {
     (this.eventListeners[eventType] || []).forEach(callback => callback(this));
-  }
-
-  connect() {
-    return new Promise((resolve, reject) => {
-      // Used for resubscribing in the future
-      const oldCommands = this.commands;
-      Object.keys(oldCommands).forEach((id) => {
-        const info = oldCommands[id];
-
-        // Reject stuff still waiting for an answer
-        if (info.reject) {
-          info.reject(messages.error(ERR_CONNECTION_LOST, 'Connection lost'));
-        }
-      });
-
-      // If invalid auth, we will not try to reconnect.
-      let invalidAuth = false;
-
-      this.connectionTries += 1;
-      this.socket = new WebSocket(this.url);
-
-      this.socket.addEventListener('open', () => {
-        this.firstConnection = false;
-        this.connectionTries = 0;
-      });
-
-      this.socket.addEventListener('message', (event) => {
-        const message = JSON.parse(event.data);
-
-        if (__DEV__) {
-          /* eslint-disable no-console */
-          console.log('Received', message);
-          /* eslint-enable no-console */
-        }
-
-        switch (message.type) {
-          case 'event':
-            this.commands[message.id].eventCallback(message.event);
-            break;
-
-          case 'result':
-            if (message.success) {
-              this.commands[message.id].resolve(message);
-            } else {
-              this.commands[message.id].reject(message.error);
-            }
-            delete this.commands[message.id];
-            break;
-
-          case 'pong':
-            break;
-
-          case 'auth_required':
-            this.sendMessage(messages.auth(this.options.authToken));
-            break;
-
-          case 'auth_invalid':
-            reject(ERR_INVALID_AUTH);
-            invalidAuth = true;
-            break;
-
-          case 'auth_ok':
-            resolve(this);
-
-            // Re-subscribe to events and update old location of unsub method
-            // so old unsub method keeps working.
-            this.commandId = 1;
-            this.commands = {};
-
-            Object.keys(oldCommands).forEach((id) => {
-              const info = oldCommands[id];
-
-              if (info.eventType) {
-                this.subscribeEvents(info.eventCallback, info.eventType)
-                  .then((unsub) => { info.unsubscribe = unsub; });
-              }
-            });
-
-            this.fireEvent('ready');
-            break;
-
-          default:
-            if (__DEV__) {
-              /* eslint-disable no-console */
-              console.warn('Unhandled message', message);
-              /* eslint-enable no-console */
-            }
-        }
-      });
-
-      this.socket.addEventListener('close', () => {
-        if (invalidAuth || this.closeRequested) {
-          // When we have invalid auth, let's not reconnect or we get banned.
-          return;
-        } else if (this.firstConnection) {
-          // We never were connected
-          reject(ERR_CANNOT_CONNECT);
-          return;
-        } else if (this.connectionTries === 0) {
-          // We were connected at some point.
-          this.fireEvent('disconnected');
-        }
-
-        // Try again
-        const waitTime = Math.min(this.connectionTries, 5) * 1000;
-        setTimeout(() => this.connect(), waitTime);
-      });
-    });
   }
 
   close() {
@@ -199,9 +209,7 @@ class Connection {
         this.commands[resultMessage.id] = info;
 
         return () => info.unsubscribe();
-      /* eslint-disable comma-dangle */ /* comma crashes Buble */
       }
-      /* eslint-enable comma-dangle */
     );
   }
 
@@ -223,16 +231,88 @@ class Connection {
     return new Promise((resolve, reject) => {
       this.commandId += 1;
       const commandId = this.commandId;
-      /* eslint-disable no-param-reassign */
       message.id = commandId;
-      /* eslint-enable no-param-reassign */
       this.commands[commandId] = { resolve, reject };
       this.sendMessage(message);
     });
   }
+
+  _handleMessage(event) {
+    const message = JSON.parse(event.data);
+
+    if (__DEV__) {
+      /* eslint-disable no-console */
+      console.log('Received', message);
+      /* eslint-enable no-console */
+    }
+
+    switch (message.type) {
+      case 'event':
+        this.commands[message.id].eventCallback(message.event);
+        break;
+
+      case 'result':
+        if (message.success) {
+          this.commands[message.id].resolve(message);
+        } else {
+          this.commands[message.id].reject(message.error);
+        }
+        delete this.commands[message.id];
+        break;
+
+      case 'pong':
+        break;
+
+      default:
+        if (__DEV__) {
+          /* eslint-disable no-console */
+          console.warn('Unhandled message', message);
+          /* eslint-enable no-console */
+        }
+    }
+  }
+
+  _handleClose() {
+    // Reject in-flight requests
+    Object.keys(this.commands).forEach((id) => {
+      const { reject } = this.commands[id];
+      if (reject) {
+        reject(messages.error(ERR_CONNECTION_LOST, 'Connection lost'));
+      }
+    });
+
+    if (this.closeRequested) {
+      return;
+    }
+
+    this.fireEvent('disconnected');
+
+    // Disable setupRetry, we control it here with auto-backoff
+    const options = Object.assign({}, this.options, { setupRetry: 0 });
+
+    const reconnect = (tries) => {
+      setTimeout(() => {
+        if (__DEV__) {
+          /* eslint-disable no-console */
+          console.log('Trying to reconnect');
+          /* eslint-enable no-console */
+        }
+        getSocket(this.url, options).then(
+          socket => this.setSocket(socket),
+          () => reconnect(tries + 1)
+        );
+      }, Math.min(tries, 5) * 1000);
+    };
+
+    reconnect(0);
+  }
 }
 
-export default function createConnection(url, options) {
-  const conn = new Connection(url, options);
-  return conn.connect();
+export default function createConnection(url, options = {}) {
+  return getSocket(url, options)
+    .then((socket) => {
+      const conn = new Connection(url, options);
+      conn.setSocket(socket);
+      return conn;
+    });
 }


### PR DESCRIPTION
Break out setting up the websocket connection from the Connection object. New internal `getSocket` method will create a websocket connection and authenticate. Is able to automatically retry every second based on the new option `setupRetry`, which can be used to specify the number of retries.

Connection class is now only used for handling a connection that is authenticated. When the connection gets lost, it will retry to connect again with an auto back off (1s, 2s, 3s, 4s, 5s, 5s, etc…). Once connected it will swap out the old closed socket for the new one and restore the event subscriptions.