### PR TITLE
Fix hidden group entities showing up in a view

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -15,7 +15,15 @@ export function getViewEntities(entities, view) {
       viewEntities[entity.entity_id] = entity;
 
       if (extractDomain(entity.entity_id) === 'group') {
-        Object.assign(viewEntities, getGroupEntities(entities, entity));
+        const groupEntities = getGroupEntities(entities, entity);
+
+        Object.keys(groupEntities).forEach((grEntityId) => {
+          const grEntity = groupEntities[grEntityId];
+
+          if (!grEntity.attributes.hidden) {
+            viewEntities[grEntityId] = grEntity;
+          }
+        });
       }
     }
   });

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -2,6 +2,8 @@
 let mockState = 1;
 
 export function createEntity(entity) {
+  mockState++;
+  entity.entity_id = entity.entity_id || `test.test_${mockState}`;
   entity.last_changed = entity.last_changed || (new Date()).toISOString();
   entity.last_updated = entity.last_updated || entity.last_changed;
   entity.attributes = entity.attributes || {};

--- a/test/view.spec.js
+++ b/test/view.spec.js
@@ -2,7 +2,7 @@ import test from 'tape';
 
 import { getViewEntities, extractViews } from '../lib/view';
 
-import { createEntities, createGroup, createView, entityMap } from './test_util';
+import { createEntities, createEntity, createGroup, createView, entityMap } from './test_util';
 
 test('extractViews should work', (t) => {
   const entities = createEntities(10);
@@ -50,6 +50,34 @@ test('getViewEntities should work', (t) => {
   Object.assign(
     expectedEntities,
     entityMap(group2.attributes.entity_id.map(ent => entities[ent])));
+
+  t.deepEqual(expectedEntities, getViewEntities(entities, view));
+  t.end();
+});
+
+
+test('getViewEntities should not include hidden entities inside groups', (t) => {
+  const visibleEntity = createEntity({ attributes: { hidden: false } });
+  const hiddenEntity = createEntity({ attributes: { hidden: true } });
+  const group1 = createGroup({ attributes: { entity_id: [
+    visibleEntity.entity_id, hiddenEntity.entity_id] } });
+
+  const entities = {
+    [visibleEntity.entity_id]: visibleEntity,
+    [hiddenEntity.entity_id]: hiddenEntity,
+    [group1.entity_id]: group1,
+  };
+
+  const view = createView({
+    attributes: {
+      entity_id: [group1.entity_id],
+    },
+  });
+
+  const expectedEntities = {
+    [visibleEntity.entity_id]: visibleEntity,
+    [group1.entity_id]: group1,
+  };
 
   t.deepEqual(expectedEntities, getViewEntities(entities, view));
   t.end();


### PR DESCRIPTION
Fixes a bug that when extracting the entities of a view, we would incorrectly ignore the hidden attribute on group entities.

Fixes https://github.com/home-assistant/home-assistant/issues/5905
Fixes https://github.com/home-assistant/home-assistant/issues/5909
