### PR TITLE
Consider default_view as view by default.

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -39,8 +39,7 @@ export function extractViews(entities) {
     const entity = entities[entityId];
     // Entity is a view if it has the 'view' attribute set.
     // Consider default_view as view by default. 
-    if (entity.attributes.view ||
-        (entity.entity_id === DEFAULT_VIEW_ENTITY_ID && entity.attributes.view !== false)) {
+    if (entity.attributes.view || entity.entity_id === DEFAULT_VIEW_ENTITY_ID) {
       views.push(entity);
     }
   });

--- a/lib/view.js
+++ b/lib/view.js
@@ -37,7 +37,10 @@ export function extractViews(entities) {
 
   Object.keys(entities).forEach((entityId) => {
     const entity = entities[entityId];
-    if (entity.attributes.view) {
+    // Entity is a view if it has the 'view' attribute set.
+    // Consider default_view as view by default. 
+    if (entity.attributes.view ||
+        (entity.entity_id === DEFAULT_VIEW_ENTITY_ID && entity.attributes.view !== false)) {
       views.push(entity);
     }
   });


### PR DESCRIPTION
Consider default_view as view by default.

Will allow to use https://github.com/home-assistant/home-assistant-polymer/pull/244 without manually specifying `view: true` under `default_view`