### PR TITLE
Add error handler to websocket

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -24,7 +24,12 @@ function getSocket(url, options) {
     // If invalid auth, we will not try to reconnect.
     let invalidAuth = false;
 
-    const closeMessage = () => {
+    const closeMessage = (evt) => {
+      if (evt.target && evt.target.removeEventListener) {
+        // If we are in error handler make sure close handler doesn't also fire.
+        evt.target.removeEventListener('close', closeMessage);
+      }
+
       if (invalidAuth) {
         promReject(ERR_INVALID_AUTH);
         return;
@@ -83,6 +88,7 @@ function getSocket(url, options) {
 
     socket.addEventListener('message', handleMessage);
     socket.addEventListener('close', closeMessage);
+    socket.addEventListener('error', closeMessage);
   }
 
   return new Promise((resolve, reject) => connect(options.setupRetry || 0, resolve, reject));

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -25,10 +25,8 @@ function getSocket(url, options) {
     let invalidAuth = false;
 
     const closeMessage = (evt) => {
-      if (evt.target && evt.target.removeEventListener) {
-        // If we are in error handler make sure close handler doesn't also fire.
-        evt.target.removeEventListener('close', closeMessage);
-      }
+      // If we are in error handler make sure close handler doesn't also fire.
+      socket.removeEventListener('close', closeMessage);
 
       if (invalidAuth) {
         promReject(ERR_INVALID_AUTH);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -74,6 +74,7 @@ function getSocket(url, options) {
         case 'auth_ok':
           socket.removeEventListener('message', handleMessage);
           socket.removeEventListener('close', closeMessage);
+          socket.removeEventListener('error', closeMessage);
           promResolve(socket);
           break;
 


### PR DESCRIPTION
Currently if HA backend is unreachable, an error event is fired before the close event and the following message is written to the console: 

`WebSocket connection to 'WebSocket connection to 'ws://localhost:8123/api/websocket?latest' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED`

This PR adds error handler that does the same as the close handler, but it prevents this log line.