### PR TITLE
Add access token support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ npm-debug.log
 node_modules
 dist
 .reify-cache
+yarn-error.log

--- a/README.md
+++ b/README.md
@@ -54,17 +54,18 @@ import { ERR_CANNOT_CONNECT, ERR_INVALID_AUTH } from 'home-assistant-js-websocke
 
 The connection object will automatically try to reconnect to the server when the connection gets lost. On reconnect, it will automatically resubscribe the event listeners.
 
-The `Connection` object implements two events to signal loss of connection and successful reconnect.
+The `Connection` object implements three events related to the reconnecting logic.
 
-| Event | Description |
-| ----- | ----------- |
-| ready | Fired when authentication is successful and the connection is ready to take commands.
-| disconnected | Fired when the connection is lost.
+| Event | Data | Description |
+| ----- | ---- | ----------- |
+| ready | - | Fired when authentication is successful and the connection is ready to take commands.
+| disconnected | - | Fired when the connection is lost.
+| reconnect-error | Error code | Fired when we encounter a fatal error when trying to reconnect. Currently limited to `ERR_INVALID_AUTH`.
 
 You can attach and remove listeners as follows:
 
 ```javascript
-function eventHandler() {
+function eventHandler(connection, data) {
   console.log('Connection has been established again');
 }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -53,11 +53,12 @@ function getSocket(url, options) {
         console.log('[Auth phase] Received', message);
         /* eslint-enable no-console */
       }
-
       switch (message.type) {
         case 'auth_required':
-          if ('authToken' in options) {
+          if (options.authToken) {
             socket.send(JSON.stringify(messages.auth(options.authToken)));
+          } else if (options.accessToken) {
+            socket.send(JSON.stringify(messages.authAccessToken(options.accessToken)));
           } else {
             invalidAuth = true;
             socket.close();
@@ -168,8 +169,8 @@ class Connection {
     }
   }
 
-  fireEvent(eventType) {
-    (this.eventListeners[eventType] || []).forEach(callback => callback(this));
+  fireEvent(eventType, eventData) {
+    (this.eventListeners[eventType] || []).forEach(callback => callback(this, eventData));
   }
 
   close() {
@@ -304,7 +305,8 @@ class Connection {
         }
         getSocket(this.url, options).then(
           socket => this.setSocket(socket),
-          () => reconnect(tries + 1)
+          (err) => err === ERR_INVALID_AUTH ?
+            this.fireEvent('reconnect-error', err) : reconnect(tries + 1)
         );
       }, Math.min(tries, 5) * 1000);
     };

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -5,6 +5,13 @@ export function auth(authToken) {
   };
 }
 
+export function authAccessToken(accessToken) {
+  return {
+    type: 'auth',
+    access_token: accessToken,
+  };
+}
+
 export function states() {
   return {
     type: 'get_states',


### PR DESCRIPTION
Add support to making a connection using an access token.

Also adds a new event `reconnect-error`, fired when we encounter a fatal error when reconnecting. Currently this is when we reconnect and the authentication is no longer valid.