### PR TITLE
Check access token expires before we use

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Currently the following options are available:
 
 | Option | Description |
 | ------ | ----------- |
-| authToken | Auth token to use to validate with Home Assistant.
+| authToken | Legacy auth token to use to validate with Home Assistant.
+| accessToken | OAuth 2 access token to use to validate with Home Assistant.
+| expires | Access token will expires on.
 | setupRetry | Number of times to retry initial connection when it fails. -1 means infinite.
 
 #### Possible error codes

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -63,7 +63,13 @@ function getSocket(url, options) {
           if (options.authToken) {
             socket.send(JSON.stringify(messages.auth(options.authToken)));
           } else if (options.accessToken) {
-            socket.send(JSON.stringify(messages.authAccessToken(options.accessToken)));
+            if (options.expires !== undefined && Date.now() > options.expires) {
+              // We know access token expires, no need to try
+              invalidAuth = true;
+              socket.close();
+            } else {
+              socket.send(JSON.stringify(messages.authAccessToken(options.accessToken)));
+            }
           } else {
             invalidAuth = true;
             socket.close();
@@ -107,7 +113,9 @@ class Connection {
     // websocket API url
     this.url = url;
     // connection options
-    //  - authToken: auth to use
+    //  - authToken: legacy auth to use
+    //  - acessToken: OAuth 2 access token
+    //  - expires: accessToken will expires on
     //  - setupRetry: amount of ms to retry when unable to connect on initial setup
     this.options = options || {};
     // id if next command to send

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -64,7 +64,7 @@ function getSocket(url, options) {
             socket.send(JSON.stringify(messages.auth(options.authToken)));
           } else if (options.accessToken) {
             if (options.expires !== undefined && Date.now() > options.expires) {
-              // We know access token expires, no need to try
+              // We know access token has expired, no need to try
               invalidAuth = true;
               socket.close();
             } else {


### PR DESCRIPTION
Need first implement home-assistant/home-assistant-polymer#1444

Part of home-assistant/home-assistant#15209

WS will use access token to auth during the reconnect. There are 3 scenario
1. User has long run server, restart for some reason. Since the access token used in websocket connect only be given in init phase, it probably already expires, then we will first refresh token.
2. User has an access token to start a connection, and server stopped for 30 mintues, then server started, at that time, token expired, we will refresh token
3. User is a developer, who restart server very frequency, so the websocket still think access token is not expired, however restart server will invalid all access token, websocket connection will get invalid auth, back end will get invalid auth event as well. To resolve that, we need some sort of session or tag, so that front end knows server restart, it need invalid the access token in localstorage, 

After implement, back end log will likes following if access token expires during the reconnect . No ipban message.
```
2018-07-13 17:14:59 INFO (MainThread) [homeassistant.components.http.view] Serving /api/websocket to 127.0.0.1 (auth: False)
2018-07-13 17:14:59 DEBUG (MainThread) [homeassistant.components.websocket_api] WS 139905478490488: Connected 
2018-07-13 17:14:59 DEBUG (MainThread) [homeassistant.components.websocket_api] WS 139905478490488: Request auth 
2018-07-13 17:14:59 DEBUG (MainThread) [homeassistant.components.websocket_api] WS 139905478490488: Connection closed by client 
2018-07-13 17:14:59 DEBUG (MainThread) [homeassistant.components.websocket_api] WS 139905478490488: Closed connection 
2018-07-13 17:14:59 INFO (MainThread) [homeassistant.components.http.view] Serving /auth/token to 127.0.0.1 (auth: False)
2018-07-13 17:14:59 INFO (MainThread) [homeassistant.components.http.view] Serving /api/websocket to 127.0.0.1 (auth: False)
2018-07-13 17:14:59 DEBUG (MainThread) [homeassistant.components.websocket_api] WS 139905478490320: Connected 
2018-07-13 17:14:59 DEBUG (MainThread) [homeassistant.components.websocket_api] WS 139905478490320: Request auth 
2018-07-13 17:14:59 DEBUG (MainThread) [homeassistant.components.websocket_api] WS 139905478490320: Received access_token 
2018-07-13 17:14:59 DEBUG (MainThread) [homeassistant.components.websocket_api] WS 139905478490320: Auth OK 

```