### PR TITLE
Refactor subscriptions

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,0 +1,42 @@
+import { createStore } from './store';
+
+let collectionID = 0;
+
+// fetchCollection returns promise that resolves to current value of collection.
+// subscribeUpdates(connection, store) returns promise that resolves
+// to an unsubscription function.
+
+export default function createCollection(fetchCollection, subscribeUpdates) {
+  const key = `_collection_${collectionID++}`;
+
+  return function (conn, onChange) {
+    if (key in conn) {
+      return conn[key](onChange);
+    }
+
+    let unsubProm;
+
+    const store = createStore(() => {
+      unsubProm.then(unsub => unsub());
+      // eslint-disable-next-line
+      conn.removeEventListener('ready', refresh);
+      delete conn[key];
+    });
+
+    conn[key] = store.subscribe;
+
+    // Subscribe to changes
+    unsubProm = subscribeUpdates(conn, store);
+
+    async function refresh() {
+      store.setState(await fetchCollection(conn), true);
+    }
+
+    // Fetch when connection re-established.
+    conn.addEventListener('ready', refresh);
+
+    refresh();
+
+    return store.subscribe(onChange);
+  };
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,116 +1,15 @@
-export default function subscribeConfig(conn, configChanged) {
-  if (conn._subscribeConfig) {
-    return conn._subscribeConfig(configChanged);
-  }
+import createCollection from './collection.js';
 
-  return new Promise((resolve, reject) => {
-    let config = null;
-    let configUnsub = null;
-    const listeners = [];
-    let initPromise = null;
+function processComponentLoaded(state, event) {
+  if (state === undefined) return null;
 
-    if (configChanged) {
-      listeners.push(configChanged);
-    }
-
-    const updateConfig = (updates) => {
-      config = Object.assign({}, config, updates);
-
-      for (let i = 0; i < listeners.length; i++) {
-        listeners[i](config);
-      }
-    };
-
-    const updateServices = (domain, domainInfo) =>
-      updateConfig({ services: Object.assign({}, config.services, { [domain]: domainInfo }) });
-
-    const processComponentLoaded = (event) => {
-      if (config === null) return;
-
-      const core = Object.assign(
-        {}, config.core,
-        { components: config.core.components.concat(event.data.component) }
-      );
-
-      updateConfig({ core });
-    };
-
-    const processServiceRegistered = (event) => {
-      if (config === null) return;
-
-      const { domain, service } = event.data;
-
-      const domainInfo = Object.assign(
-        {}, config.services[domain] || {},
-        { [service]: { description: '', fields: {} } }
-      );
-
-      updateServices(domain, domainInfo);
-    };
-
-    const processServiceRemoved = (event) => {
-      if (config === null) return;
-
-      const { domain, service } = event.data;
-      const curDomainInfo = config.services[domain];
-
-      if (!curDomainInfo || !(service in curDomainInfo)) return;
-
-      const domainInfo = {};
-      Object.keys(curDomainInfo).forEach((sKey) => {
-        if (sKey !== service) domainInfo[sKey] = curDomainInfo[sKey];
-      });
-      updateServices(domain, domainInfo);
-    };
-
-    const fetchAll = () => Promise.all([
-      conn.getConfig(),
-      conn.getServices(),
-    ]).then(([core, services]) => {
-      updateConfig({ core, services });
-    });
-
-    const removeListener = (listener) => {
-      if (listener) {
-        listeners.splice(listeners.indexOf(listener), 1);
-      }
-
-      if (listeners.length === 0) {
-        configUnsub();
-      }
-    };
-
-    conn._subscribeConfig = (listener) => {
-      if (listener) {
-        listeners.push(listener);
-
-        // If config is null, fetching promise still has to resolve
-        if (config !== null) {
-          listener(config);
-        }
-      }
-      return initPromise.then(() => () => removeListener(listener));
-    };
-
-    initPromise = Promise.all([
-      conn.subscribeEvents(processComponentLoaded, 'component_loaded'),
-      conn.subscribeEvents(processServiceRegistered, 'service_registered'),
-      conn.subscribeEvents(processServiceRemoved, 'service_removed'),
-      fetchAll(),
-    ]);
-
-    initPromise.then(
-      ([unsubComp, unsubServReg, unsubServRem]) => {
-        configUnsub = () => {
-          conn.removeEventListener('ready', fetchAll);
-          unsubComp();
-          unsubServReg();
-          unsubServRem();
-        };
-        conn.addEventListener('ready', fetchAll);
-        resolve(() => removeListener(configChanged));
-      },
-      () => reject()
-    );
-  });
+  return {
+    components: state.components.concat(event.data.component)
+  };
 }
+
+const fetchConfig = conn => conn.getConfig();
+const subscribeUpdates = (conn, store) =>
+  conn.subscribeEvents(store.action(processComponentLoaded), 'component_loaded');
+
+export default createCollection(fetchConfig, subscribeUpdates);

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -1,4 +1,22 @@
-function getEntities(states) {
+import createCollection from './collection.js';
+
+function processEvent(store, event) {
+  const state = store.getState();
+  if (state === undefined) return;
+
+  /* eslint-disable camelcase */
+  const { entity_id, new_state } = event.data;
+  if (new_state) {
+    store.setState({ [new_state.entity_id]: new_state });
+  } else {
+    const newEntities = Object.assign({}, state);
+    delete newEntities[entity_id];
+    store.setState(newEntities, true);
+  }
+}
+
+async function fetchEntities(conn) {
+  const states = await conn.getStates();
   const entities = {};
   for (let i = 0; i < states.length; i++) {
     const state = states[i];
@@ -7,95 +25,7 @@ function getEntities(states) {
   return entities;
 }
 
-function updateState(entities, state) {
-  const newEntities = Object.assign({}, entities);
-  newEntities[state.entity_id] = state;
-  return newEntities;
-}
+const subscribeUpdates = (conn, store) =>
+  conn.subscribeEvents(ev => processEvent(store, ev), 'state_changed');
 
-function removeState(entities, entityId) {
-  const newEntities = Object.assign({}, entities);
-  delete newEntities[entityId];
-  return newEntities;
-}
-
-export default function subscribeEntities(conn, entitiesChanged) {
-  if (conn._subscribeEntities) {
-    return conn._subscribeEntities(entitiesChanged);
-  }
-
-  return new Promise((resolve, reject) => {
-    let entities = null;
-    let entitiesUnsub = null;
-    const listeners = [];
-    let initPromise = null;
-
-    if (entitiesChanged) {
-      listeners.push(entitiesChanged);
-    }
-
-    function processEvent(event) {
-      if (entities === null) return;
-
-      /* eslint-disable camelcase */
-      const { entity_id, new_state } = event.data;
-      if (new_state) {
-        entities = updateState(entities, new_state);
-      } else {
-        entities = removeState(entities, entity_id);
-      }
-
-      for (let i = 0; i < listeners.length; i++) {
-        listeners[i](entities);
-      }
-    }
-
-    function fetchAll() {
-      return conn.getStates().then((states) => {
-        entities = getEntities(states);
-
-        for (let i = 0; i < listeners.length; i++) {
-          listeners[i](entities);
-        }
-      });
-    }
-
-    function removeListener(listener) {
-      if (listener) {
-        listeners.splice(listeners.indexOf(listener), 1);
-      }
-
-      // Last listener removed, clean up.
-      if (listeners.length === 0) {
-        entitiesUnsub();
-        conn.removeEventListener('ready', fetchAll);
-        conn._subscribeEntities = null;
-      }
-    }
-
-    conn._subscribeEntities = (listener) => {
-      if (listener) {
-        listeners.push(listener);
-
-        // If entities is null, fetching promise still has to resolve
-        if (entities !== null) {
-          listener(entities);
-        }
-      }
-      return initPromise.then(() => () => removeListener(listener));
-    };
-
-    initPromise = Promise.all([
-      conn.subscribeEvents(processEvent, 'state_changed'), fetchAll(),
-    ]);
-
-    initPromise.then(
-      ([unsub]) => {
-        entitiesUnsub = unsub;
-        conn.addEventListener('ready', fetchAll);
-        resolve(() => removeListener(entitiesChanged));
-      },
-      () => reject()
-    );
-  });
-}
+export default createCollection(fetchEntities, subscribeUpdates);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 import getAuth from './auth.js';
 import createConnection from './connection.js';
 import subscribeConfig from './config.js';
+import subscribeServices from './services.js';
 import subscribeEntities from './entities.js';
 import {
   ERR_CANNOT_CONNECT,
@@ -18,5 +19,6 @@ export {
   getAuth,
   createConnection,
   subscribeConfig,
+  subscribeServices,
   subscribeEntities,
 };

--- a/lib/services.js
+++ b/lib/services.js
@@ -1,0 +1,39 @@
+import createCollection from './collection.js';
+
+function processServiceRegistered(state, event) {
+  if (state === undefined) return null;
+
+  const { domain, service } = event.data;
+
+  const domainInfo = Object.assign(
+    {}, state[domain],
+    { [service]: { description: '', fields: {} } }
+  );
+
+  return { [domain]: domainInfo };
+}
+
+function processServiceRemoved(state, event) {
+  if (state === undefined) return null;
+
+  const { domain, service } = event.data;
+  const curDomainInfo = state[domain];
+
+  if (!curDomainInfo || !(service in curDomainInfo)) return null;
+
+  const domainInfo = {};
+  Object.keys(curDomainInfo).forEach((sKey) => {
+    if (sKey !== service) domainInfo[sKey] = curDomainInfo[sKey];
+  });
+
+  return { [domain]: domainInfo };
+}
+
+
+const fetchServices = conn => conn.getServices();
+const subscribeUpdates = (conn, store) => Promise.all([
+  conn.subscribeEvents(store.action(processServiceRegistered), 'service_registered'),
+  conn.subscribeEvents(store.action(processServiceRemoved), 'service_removed'),
+]).then(unsubs => () => unsubs.forEach(fn => fn()));
+
+export default createCollection(fetchServices, subscribeUpdates);

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,0 +1,108 @@
+// (c) Jason Miller
+// Unistore - MIT license
+// And then slightly adopted
+
+/* eslint-disable prefer-rest-params, consistent-return, max-len */
+
+/**
+ * Creates a new store, which is a tiny evented state container.
+ * @name createStore
+ * @param {Object} initial state
+ * @returns {store}
+ * @example
+ * let store = createStore();
+ * store.subscribe( state => console.log(state) );
+ * store.setState({ a: 'b' });   // logs { a: 'b' }
+ * store.setState({ c: 'd' });   // logs { a: 'b', c: 'd' }
+ */
+export function createStore(noSubscribers) {
+  let listeners = [];
+  let state;
+
+  function unsubscribe(listener) {
+    const out = [];
+    for (let i = 0; i < listeners.length; i++) {
+      if (listeners[i] === listener) {
+        listener = null;
+      } else {
+        out.push(listeners[i]);
+      }
+    }
+    listeners = out;
+    if (out.length === 0) {
+      noSubscribers();
+    }
+  }
+
+  function setState(update, overwrite) {
+    state = overwrite ? update : Object.assign({}, state, update);
+    const currentListeners = listeners;
+    for (let i = 0; i < currentListeners.length; i++) { currentListeners[i](state); }
+  }
+
+  /**
+   * An observable state container, returned from {@link createStore}
+   * @name store
+   */
+
+  return /** @lends store */ {
+    /**
+     * Create a bound copy of the given action function.
+     * The bound returned function invokes action() and persists the result back to the store.
+     * If the return value of `action` is a Promise, the resolved value will be used as state.
+     * @param {Function} action An action of the form `action(state, ...args) -> stateUpdate`
+     * @returns {Function} boundAction()
+     */
+    action(action) {
+      function apply(result) {
+        setState(result, false, action);
+      }
+
+      // Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500
+      return function () {
+        const args = [state];
+        for (let i = 0; i < arguments.length; i++) args.push(arguments[i]);
+        const ret = action.apply(this, args);
+        if (ret != null) {
+          if (ret.then) return ret.then(apply);
+          return apply(ret);
+        }
+      };
+    },
+
+    /**
+     * Apply a partial state object to the current state, invoking registered listeners.
+     * @param {Object} update    An object with properties to be merged into state
+     * @param {Boolean} [overwrite=false] If `true`, update will replace state instead of being merged into it
+     */
+    setState,
+
+    /**
+     * Register a listener function to be called whenever state is changed. Returns an `unsubscribe()` function.
+     * @param {Function} listener A function to call when state changes. Gets passed the new state.
+     * @returns {Function} unsubscribe()
+     */
+    subscribe(listener) {
+      listeners.push(listener);
+      if (state !== undefined) listener(state);
+      return () => {
+        unsubscribe(listener);
+      };
+    },
+
+    /**
+     * Remove a previously-registered listener function.
+     * @param {Function} listener The callback previously passed to `subscribe()` that should be removed.
+     * @function
+     */
+    unsubscribe,
+
+    /**
+     * Retrieve the current state object.
+     * @returns {Object} state
+     */
+    getState() {
+      return state;
+    }
+  };
+}

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,0 +1,51 @@
+import assert from 'assert';
+
+import subscribeConfig from '../lib/config';
+import { mockConnection, createAwaitableEvent } from './util';
+
+const MOCK_CONFIG = {
+  hello: 'bla',
+  components: ['frontend']
+};
+
+describe('subscribeConfig', () => {
+  let conn;
+  let awaitableEvent;
+
+  beforeEach(() => {
+    conn = mockConnection();
+    conn.getConfig = async () => MOCK_CONFIG;
+    awaitableEvent = createAwaitableEvent();
+  });
+
+  it('should load initial config', async () => {
+    awaitableEvent.prime();
+    subscribeConfig(conn, awaitableEvent.set);
+
+    const config = await awaitableEvent.wait();
+
+    assert.deepStrictEqual(config, MOCK_CONFIG);
+  });
+
+  it('should handle component loaded events', async () => {
+    subscribeConfig(conn, awaitableEvent.set);
+
+    // We need to sleep to have it process the first full load
+    await 0;
+
+    awaitableEvent.prime();
+
+    conn.mockEvent('component_loaded', {
+      data: {
+        component: 'api'
+      }
+    });
+
+    const config = await awaitableEvent.wait();
+
+    assert.deepEqual(config, {
+      hello: 'bla',
+      components: ['frontend', 'api'],
+    });
+  });
+});

--- a/test/entities.spec.js
+++ b/test/entities.spec.js
@@ -1,0 +1,122 @@
+import assert from 'assert';
+
+import subscribeEntities from '../lib/entities';
+import { mockConnection, createAwaitableEvent } from './util';
+
+const MOCK_LIGHT = {
+  entity_id: 'light.kitchen',
+  state: 'on'
+};
+
+const MOCK_SWITCH = {
+  entity_id: 'switch.ac',
+  state: 'off'
+};
+
+const MOCK_ENTITIES = [MOCK_LIGHT, MOCK_SWITCH];
+
+describe('subscribeEntities', () => {
+  let conn;
+  let awaitableEvent;
+
+  beforeEach(() => {
+    conn = mockConnection();
+    conn.getStates = async () => MOCK_ENTITIES;
+    awaitableEvent = createAwaitableEvent();
+  });
+
+  it('should load initial entities', async () => {
+    awaitableEvent.prime();
+    subscribeEntities(conn, awaitableEvent.set);
+
+    const entities = await awaitableEvent.wait();
+    assert.deepStrictEqual(entities, {
+      [MOCK_LIGHT.entity_id]: MOCK_LIGHT,
+      [MOCK_SWITCH.entity_id]: MOCK_SWITCH,
+    });
+  });
+
+  it('should handle state changed with updated state', async () => {
+    subscribeEntities(conn, awaitableEvent.set);
+
+    await 0;
+    await 0;
+    await 0;
+
+    awaitableEvent.prime();
+
+    conn.mockEvent('state_changed', {
+      data: {
+        entity_id: 'light.kitchen',
+        new_state: {
+          entity_id: 'light.kitchen',
+          state: 'off',
+        },
+      },
+    });
+
+    const entities = await awaitableEvent.wait();
+
+    assert.deepEqual(entities, {
+      [MOCK_SWITCH.entity_id]: MOCK_SWITCH,
+      'light.kitchen': {
+        entity_id: 'light.kitchen',
+        state: 'off',
+      },
+    });
+  });
+
+  it('should handle state changed with new state', async () => {
+    subscribeEntities(conn, awaitableEvent.set);
+
+    await 0;
+    await 0;
+    await 0;
+
+    awaitableEvent.prime();
+
+    conn.mockEvent('state_changed', {
+      data: {
+        entity_id: 'light.living_room',
+        new_state: {
+          entity_id: 'light.living_room',
+          state: 'off',
+        },
+      },
+    });
+
+    const entities = await awaitableEvent.wait();
+
+    assert.deepEqual(entities, {
+      [MOCK_SWITCH.entity_id]: MOCK_SWITCH,
+      [MOCK_LIGHT.entity_id]: MOCK_LIGHT,
+      'light.living_room': {
+        entity_id: 'light.living_room',
+        state: 'off',
+      },
+    });
+  });
+
+  it('should handle state changed with removed state', async () => {
+    subscribeEntities(conn, awaitableEvent.set);
+
+    await 0;
+    await 0;
+    await 0;
+
+    awaitableEvent.prime();
+
+    conn.mockEvent('state_changed', {
+      data: {
+        entity_id: 'light.kitchen',
+        new_state: null,
+      },
+    });
+
+    const entities = await awaitableEvent.wait();
+
+    assert.deepEqual(entities, {
+      [MOCK_SWITCH.entity_id]: MOCK_SWITCH,
+    });
+  });
+});

--- a/test/services.spec.js
+++ b/test/services.spec.js
@@ -1,0 +1,132 @@
+import assert from 'assert';
+
+import subscribeServices from '../lib/services';
+import { mockConnection, createAwaitableEvent } from './util';
+
+const MOCK_SERVICES = {
+  light: {
+    turn_on: {
+      description: 'Turn a light on',
+      fields: {
+        entity_id: {
+          description: 'Entity ID to turn on',
+          example: 'light.kitchen',
+        }
+      }
+    }
+  }
+};
+
+describe('subscribeServices', () => {
+  let conn;
+  let awaitableEvent;
+
+  beforeEach(() => {
+    conn = mockConnection();
+    conn.getServices = async () => MOCK_SERVICES;
+    awaitableEvent = createAwaitableEvent();
+  });
+
+  it('should load initial services', async () => {
+    awaitableEvent.prime();
+    subscribeServices(conn, awaitableEvent.set);
+
+    const services = await awaitableEvent.wait();
+    assert.deepStrictEqual(services, MOCK_SERVICES);
+  });
+
+  it('should handle service registered events for existing domains', async () => {
+    subscribeServices(conn, awaitableEvent.set);
+
+    await 0;
+
+    awaitableEvent.prime();
+
+    conn.mockEvent('service_registered', {
+      data: {
+        domain: 'light',
+        service: 'toggle',
+      }
+    });
+
+    const services = await awaitableEvent.wait();
+
+    assert.deepEqual(services, {
+      light: {
+        turn_on: {
+          description: 'Turn a light on',
+          fields: {
+            entity_id: {
+              description: 'Entity ID to turn on',
+              example: 'light.kitchen',
+            }
+          }
+        },
+        toggle: {
+          description: '',
+          fields: {},
+        }
+      }
+    });
+  });
+
+  it('should handle service registered events for new domains', async () => {
+    subscribeServices(conn, awaitableEvent.set);
+
+    // We need to sleep to have it process the first full load
+    await 0;
+
+    awaitableEvent.prime();
+
+    conn.mockEvent('service_registered', {
+      data: {
+        domain: 'switch',
+        service: 'turn_on',
+      }
+    });
+
+    const services = await awaitableEvent.wait();
+
+    assert.deepEqual(services, {
+      light: {
+        turn_on: {
+          description: 'Turn a light on',
+          fields: {
+            entity_id: {
+              description: 'Entity ID to turn on',
+              example: 'light.kitchen',
+            }
+          }
+        }
+      },
+      switch: {
+        turn_on: {
+          description: '',
+          fields: {},
+        }
+      }
+    });
+  });
+
+  it('should handle service removed events for existing services', async () => {
+    subscribeServices(conn, awaitableEvent.set);
+
+    // We need to sleep to have it process the first full load
+    await 0;
+
+    awaitableEvent.prime();
+
+    conn.mockEvent('service_removed', {
+      data: {
+        domain: 'light',
+        service: 'turn_on',
+      }
+    });
+
+    const services = await awaitableEvent.wait();
+
+    assert.deepEqual(services, {
+      light: {}
+    });
+  });
+});

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,41 @@
+export function mockConnection() {
+  const listeners = {};
+  return {
+    // connection events
+    // eslint-disable-next-line
+    addEventListener(event, cb) {
+
+    },
+
+    // hass events
+    subscribeEvents(cb, event = '*') {
+      if (!(event in listeners)) {
+        listeners[event] = [];
+      }
+      listeners[event].push(cb);
+    },
+
+    mockEvent(event, data) {
+      listeners[event].forEach(cb => cb(data));
+    },
+  };
+}
+
+export function createAwaitableEvent() {
+  let curPromise;
+  let curResolve;
+
+  return {
+    set(...args) {
+      if (curResolve) curResolve(...args);
+    },
+
+    prime() {
+      curPromise = new Promise((resolve) => { curResolve = resolve; });
+    },
+
+    wait() {
+      return curPromise;
+    },
+  };
+}


### PR DESCRIPTION
Refactor how we do subscriptions.

- Remove code duplications by using a generic store/collection helper
- **Breaking change** break up config subscription in a config subscription and a services subscription
- **Breaking change** `subscribeEntities` and `subscribeConfig` will now immediately return a function to unsubscribe, instead of returning a promise that resolves to an unsub function once it has been initialized.
- Added tests for all the subscribeX functions
- Updated README 

Before:

```
      3.01 kB: haws.js
      3.05 kB: haws.es.js
      3.10 kB: haws.umd.js
```

After:

```
      3.13 kB: haws.js
      3.14 kB: haws.es.js
      3.21 kB: haws.umd.js
```