### PR TITLE
Export more types

### DIFF
--- a/example.html
+++ b/example.html
@@ -30,6 +30,7 @@
         }
       }
       const connection = await createConnection({ auth });
+      window.connection = connection;
       subscribeEntities(connection, entities => renderEntities(connection, entities));
     })();
 

--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -1,4 +1,4 @@
-import Store from "./store";
+import { Store } from "./store";
 import { Connection } from "./connection";
 import { UnsubscribeFunc } from "./types";
 
@@ -6,7 +6,7 @@ import { UnsubscribeFunc } from "./types";
 // subscribeUpdates(connection, store) returns promise that resolves
 // to an unsubscription function.
 
-export default function createCollection<State>(
+export function createCollection<State>(
   key: string,
   fetchCollection: (conn: Connection) => Promise<State>,
   subscribeUpdates: (

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,7 +1,7 @@
-import createCollection from "./collection";
+import { createCollection } from "./collection";
 import { HassConfig, UnsubscribeFunc } from "./types";
 import { Connection } from "./connection";
-import Store from "./store";
+import { Store } from "./store";
 
 type ComponentLoadedEvent = {
   data: {
@@ -27,7 +27,7 @@ const subscribeUpdates = (conn: Connection, store: Store<HassConfig>) =>
     "component_loaded"
   );
 
-export default (
+export const subscribeConfig = (
   conn: Connection,
   onChange: (state: HassConfig) => void
 ): UnsubscribeFunc =>

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -3,7 +3,7 @@
  * the Home Assistant websocket API.
  */
 import * as messages from "./messages";
-import { ERR_INVALID_AUTH, ERR_CONNECTION_LOST } from "./const";
+import { ERR_INVALID_AUTH, ERR_CONNECTION_LOST } from "./errors";
 import {
   ConnectionOptions,
   HassEvent,
@@ -12,7 +12,6 @@ import {
   MessageBase,
   HassEntity
 } from "./types";
-import createSocket from "./socket";
 
 const DEBUG = false;
 
@@ -252,6 +251,8 @@ export class Connection {
         break;
 
       case "pong":
+        this.commands[message.id].resolve();
+        delete this.commands[message.id];
         break;
 
       default:
@@ -301,25 +302,6 @@ export class Connection {
   }
 
   private _genCmdId() {
-    this.commandId += 1;
-    return this.commandId;
+    return ++this.commandId;
   }
-}
-
-const defaultConnectionOptions: ConnectionOptions = {
-  setupRetry: 0,
-  createSocket
-};
-
-export default async function createConnection(
-  options?: Partial<ConnectionOptions>
-) {
-  const connOptions: ConnectionOptions = Object.assign(
-    {},
-    defaultConnectionOptions,
-    options
-  );
-  const socket = await connOptions.createSocket(connOptions);
-  const conn = new Connection(socket, connOptions);
-  return conn;
 }

--- a/lib/const.ts
+++ b/lib/const.ts
@@ -1,8 +1,0 @@
-export const ERR_CANNOT_CONNECT = 1;
-export const ERR_INVALID_AUTH = 2;
-export const ERR_CONNECTION_LOST = 3;
-export const ERR_HASS_HOST_REQUIRED = 4;
-
-export const MSG_TYPE_AUTH_REQUIRED = "auth_required";
-export const MSG_TYPE_AUTH_INVALID = "auth_invalid";
-export const MSG_TYPE_AUTH_OK = "auth_ok";

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -1,7 +1,7 @@
-import createCollection from "./collection";
+import { createCollection } from "./collection";
 import { HassEntities, HassEntity, UnsubscribeFunc } from "./types";
 import { Connection } from "./connection";
-import Store from "./store";
+import { Store } from "./store";
 
 type StateChangedEvent = {
   type: "state_changed";
@@ -42,7 +42,7 @@ const subscribeUpdates = (conn: Connection, store: Store<HassEntities>) =>
     "state_changed"
   );
 
-export default (
+export const subscribeEntities = (
   conn: Connection,
   onChange: (state: HassEntities) => void
 ): UnsubscribeFunc =>

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,4 @@
+export const ERR_CANNOT_CONNECT = 1;
+export const ERR_INVALID_AUTH = 2;
+export const ERR_CONNECTION_LOST = 3;
+export const ERR_HASS_HOST_REQUIRED = 4;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,25 +1,28 @@
-import getAuth from "./auth";
-import createCollection from "./collection";
-import createConnection from "./connection";
-import subscribeConfig from "./config";
-import subscribeServices from "./services";
-import subscribeEntities from "./entities";
-import {
-  ERR_CANNOT_CONNECT,
-  ERR_INVALID_AUTH,
-  ERR_CONNECTION_LOST,
-  ERR_HASS_HOST_REQUIRED
-} from "./const";
+import { ConnectionOptions } from "./types";
+import { createSocket } from "./socket";
+import { Connection } from "./connection";
 
-export {
-  ERR_CANNOT_CONNECT,
-  ERR_INVALID_AUTH,
-  ERR_CONNECTION_LOST,
-  ERR_HASS_HOST_REQUIRED,
-  getAuth,
-  createCollection,
-  createConnection,
-  subscribeConfig,
-  subscribeServices,
-  subscribeEntities
+export * from "./auth";
+export * from "./collection";
+export * from "./connection";
+export * from "./config";
+export * from "./services";
+export * from "./entities";
+export * from "./errors";
+export * from "./types";
+
+const defaultConnectionOptions: ConnectionOptions = {
+  setupRetry: 0,
+  createSocket
 };
+
+export async function createConnection(options?: Partial<ConnectionOptions>) {
+  const connOptions: ConnectionOptions = Object.assign(
+    {},
+    defaultConnectionOptions,
+    options
+  );
+  const socket = await connOptions.createSocket(connOptions);
+  const conn = new Connection(socket, connOptions);
+  return conn;
+}

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -1,7 +1,7 @@
-import createCollection from "./collection";
+import { createCollection } from "./collection";
 import { HassServices, HassDomainServices, UnsubscribeFunc } from "./types";
 import { Connection } from "./connection";
-import Store from "./store";
+import { Store } from "./store";
 
 type ServiceRegisteredEvent = {
   data: {
@@ -64,7 +64,7 @@ const subscribeUpdates = (conn: Connection, store: Store<HassServices>) =>
     )
   ]).then(unsubs => () => unsubs.forEach(fn => fn()));
 
-export default (
+export const subscribeServices = (
   conn: Connection,
   onChange: (state: HassServices) => void
 ): UnsubscribeFunc =>

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -2,21 +2,20 @@
  * Create a web socket connection with a Home Assistant instance.
  */
 import {
-  MSG_TYPE_AUTH_OK,
-  MSG_TYPE_AUTH_REQUIRED,
   ERR_INVALID_AUTH,
   ERR_CANNOT_CONNECT,
   ERR_HASS_HOST_REQUIRED
-} from "./const";
-import { MSG_TYPE_AUTH_INVALID } from "./const";
+} from "./errors";
 import { ConnectionOptions, Error } from "./types";
 import { authAccessToken } from "./messages";
 
 const DEBUG = false;
 
-export default function createSocket(
-  options: ConnectionOptions
-): Promise<WebSocket> {
+const MSG_TYPE_AUTH_REQUIRED = "auth_required";
+const MSG_TYPE_AUTH_INVALID = "auth_invalid";
+const MSG_TYPE_AUTH_OK = "auth_ok";
+
+export function createSocket(options: ConnectionOptions): Promise<WebSocket> {
   if (!options.auth) {
     throw ERR_HASS_HOST_REQUIRED;
   }

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -7,7 +7,7 @@ import { UnsubscribeFunc } from "./types";
 type Listener<State> = (state: State) => void;
 type NoSubscribersCallback = () => void;
 
-export default class Store<State> {
+export class Store<State> {
   private _noSub: NoSubscribersCallback;
   listeners: Listener<State>[];
   state: State | undefined;

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import subscribeConfig from "../lib/config";
+import { subscribeConfig } from "../lib/config";
 import { mockConnection, createAwaitableEvent } from "./util";
 
 const MOCK_CONFIG = {

--- a/test/entities.spec.js
+++ b/test/entities.spec.js
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import subscribeEntities from "../lib/entities";
+import { subscribeEntities } from "../lib/entities";
 import { mockConnection, createAwaitableEvent } from "./util";
 
 const MOCK_LIGHT = {

--- a/test/services.spec.js
+++ b/test/services.spec.js
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import subscribeServices from "../lib/services";
+import { subscribeServices } from "../lib/services";
 import { mockConnection, createAwaitableEvent } from "./util";
 
 const MOCK_SERVICES = {


### PR DESCRIPTION
We need to export Auth object and Connection objects for TypeScript consumers to leverage it.

```
      4.03 kB: haws.js
      4.04 kB: haws.es.js
      4.08 kB: haws.umd.js
```