### PR TITLE
Make subscribe optional, fix 2nd subscriber

### DIFF
--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -23,15 +23,17 @@ export function createCollection<State>(
   let unsubProm: Promise<UnsubscribeFunc>;
 
   const store = new Store<State>(() => {
-    unsubProm.then(unsub => unsub());
+    if (unsubProm) unsubProm.then(unsub => unsub());
     conn.removeEventListener("ready", refresh);
     delete conn[key];
   });
 
-  conn[key] = store.subscribe;
+  conn[key] = (onChange: (state: State) => void) => store.subscribe(onChange);
 
   // Subscribe to changes
-  unsubProm = subscribeUpdates(conn, store);
+  if (subscribeUpdates) {
+    unsubProm = subscribeUpdates(conn, store);
+  }
 
   async function refresh() {
     store.setState(await fetchCollection(conn), true);


### PR DESCRIPTION
- The 2+ call to a function based on a collection (subscribeEntities etc) works again
- subscribeUpdates function is now optional for a collection