### PR TITLE
fetch call add credentials:'same-origin' to avoid omit cookie

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -90,6 +90,7 @@ async function tokenRequest(
 
   const resp = await fetch(`${hassUrl}/auth/token`, {
     method: "POST",
+    credentials: 'same-origin',
     body: formData
   });
 
@@ -169,6 +170,7 @@ export class Auth {
     // There is no error checking, as revoke will always return 200
     await fetch(`${this.data.hassUrl}/auth/token`, {
       method: "POST",
+      credentials: 'same-origin',
       body: formData
     });
 


### PR DESCRIPTION
It's the same situation as https://community.home-assistant.io/t/nginx-oauth2-proxy-and-home-assistant-user-authentication/61651

fetch method calling with credentials:'same-origin' will be better.