### PR TITLE
Make event type optional

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -148,7 +148,7 @@ export class Connection {
   // Returned promise resolves to an unsubscribe function.
   async subscribeEvents<EventType>(
     eventCallback: (ev: EventType) => void,
-    eventType: string
+    eventType?: string
   ) {
     // Command ID that will be used
     const commandId = this._genCmdId();

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -61,7 +61,7 @@ type SubscribeEventMessage = {
   event_type?: string;
 };
 
-export function subscribeEvents(eventType: string) {
+export function subscribeEvents(eventType?: string) {
   const message: SubscribeEventMessage = {
     type: "subscribe_events"
   };


### PR DESCRIPTION
Event type parameter was supposed to be optional.

Fixes #55 