### PR TITLE
Better recover subscribeEvents

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -49,16 +49,17 @@ type WebSocketResponse =
   | WebSocketResultResponse
   | WebSocketResultErrorResponse;
 
-interface CommandWithAnswerInFlight {
+type SubscribeEventCommmandInFlight = {
   resolve: (result?: any) => void;
-  reject: (err: any) => void;
-}
-
-interface SubscribeEventCommmandInFlight extends CommandWithAnswerInFlight {
   eventCallback: (ev: any) => void;
   eventType?: string;
   unsubscribe: () => Promise<void>;
-}
+};
+
+type CommandWithAnswerInFlight = {
+  resolve: (result?: any) => void;
+  reject: (err: any) => void;
+};
 
 type CommandInFlight =
   | SubscribeEventCommmandInFlight
@@ -177,7 +178,6 @@ export class Connection {
       // we get disconnected and we have to subscribe again.
       info = this.commands[commandId] = {
         resolve,
-        reject,
         eventCallback: eventCallback as (ev: any) => void,
         eventType,
         unsubscribe: async () => {
@@ -268,8 +268,7 @@ export class Connection {
     Object.keys(this.commands).forEach(id => {
       const info: CommandInFlight = this.commands[id];
 
-      // We don't want to cancel subscribeEvents because we can recover them.
-      if (!("eventCallback" in info)) {
+      if ("reject" in info) {
         info.reject(messages.error(ERR_CONNECTION_LOST, "Connection lost"));
       }
     });

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -187,7 +187,7 @@ export class Connection {
       };
 
       try {
-        this.sendMessage(messages.subscribeEvents(eventType));
+        this.sendMessage(messages.subscribeEvents(eventType), commandId);
       } catch (err) {
         // Happens when the websocket is already closing.
         // Don't have to handle the error, reconnect logic will pick it up.

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -186,7 +186,12 @@ export class Connection {
         }
       };
 
-      this.sendMessage(messages.subscribeEvents(eventType));
+      try {
+        this.sendMessage(messages.subscribeEvents(eventType));
+      } catch (err) {
+        // Happens when the websocket is already closing.
+        // Don't have to handle the error, reconnect logic will pick it up.
+      }
     });
 
     return () => info.unsubscribe();


### PR DESCRIPTION
This will recover an event subscription even if the initial message to `subscribeEvents` fails to send.

Fixes error 2 in #59 

When using https://github.com/zachowj/hajw-test/tree/master , I now get never ending reconnects and resubscribes 👍  