### PR TITLE
Handle collection refresh hitting closed socket

### DIFF
--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -40,7 +40,7 @@ export function createCollection<State>(
       store.setState(await fetchCollection(conn), true);
     } catch (err) {
       // Swallow errors if socket is connecting, closing or closed.
-      // We will automatically call refreshg again when we re-establish the connection.
+      // We will automatically call refresh again when we re-establish the connection.
       // Using conn.socket instead of WebSocket for better node support
       if (conn.socket.readyState == conn.socket.OPEN) {
         throw err;

--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -39,8 +39,8 @@ export function createCollection<State>(
     try {
       store.setState(await fetchCollection(conn), true);
     } catch (err) {
-      // If socket is no longer open, we will automatically call this again
-      // when we re-establish the connection.
+      // Swallow errors if socket is connecting, closing or closed.
+      // We will automatically call refreshg again when we re-establish the connection.
       // Using conn.socket instead of WebSocket for better node support
       if (conn.socket.readyState == conn.socket.OPEN) {
         throw err;

--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -35,9 +35,18 @@ export function createCollection<State>(
     unsubProm = subscribeUpdates(conn, store);
   }
 
-  async function refresh() {
-    store.setState(await fetchCollection(conn), true);
-  }
+  const refresh = async () => {
+    try {
+      store.setState(await fetchCollection(conn), true);
+    } catch (err) {
+      // If socket is no longer open, we will automatically call this again
+      // when we re-establish the connection.
+      // Using conn.socket instead of WebSocket for better node support
+      if (conn.socket.readyState == conn.socket.OPEN) {
+        throw err;
+      }
+    }
+  };
 
   // Fetch when connection re-established.
   conn.addEventListener("ready", refresh);


### PR DESCRIPTION
If the `refreshCollection` method of a collection fails, we will swallow the error if the connection is no longer open. The collection will automatically be refreshed again when the connection can be established.

Fixes problem 1 in #59 