### PR TITLE
Add generic types

### DIFF
--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -1,17 +1,8 @@
 import { createCollection } from "./collection";
-import { HassEntities, HassEntity, UnsubscribeFunc } from "./types";
+import { HassEntities, StateChangedEvent, UnsubscribeFunc } from "./types";
 import { Connection } from "./connection";
 import { Store } from "./store";
 import { getStates } from "./commands";
-
-type StateChangedEvent = {
-  type: "state_changed";
-  data: {
-    entity_id: string;
-    new_state: HassEntity | null;
-    old_state: HassEntity | null;
-  };
-};
 
 function processEvent(store: Store<HassEntities>, event: StateChangedEvent) {
   const state = store.state;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -64,8 +64,19 @@ export type HassEntityBase = {
   last_updated: string;
 };
 
+export type HassEntityAttributeBase = {
+  friendly_name?: string;
+  unit_of_measurement?: string;
+  icon?: string;
+  entity_picture?: string;
+  supported_features?: number;
+  hidden: boolean;
+  assumed_state?: boolean;
+  device_class?: string;
+};
+
 export type HassEntity = HassEntityBase & {
-  attributes: { [key: string]: any };
+  attributes: HassEntityAttributeBase & { [key: string]: any };
 };
 
 export type HassEntities = { [entity_id: string]: HassEntity };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -16,14 +16,26 @@ export type MessageBase = {
   [key: string]: any;
 };
 
-export type HassEvent = {
-  event_type: string;
-  data: object;
+export type HassEventBase = {
   origin: string;
   time_fired: string;
   context: {
     id: string;
     user_id: string;
+  };
+};
+
+export type HassEvent = HassEventBase & {
+  event_type: string;
+  data: { [key: string]: any };
+};
+
+export type StateChangedEvent = HassEventBase & {
+  event_type: "state_changed";
+  data: {
+    entity_id: string;
+    new_state: HassEntity | null;
+    old_state: HassEntity | null;
   };
 };
 
@@ -45,12 +57,15 @@ export type HassConfig = {
   version: string;
 };
 
-export type HassEntity = {
+export type HassEntityBase = {
   entity_id: string;
   state: string;
   last_changed: string;
   last_updated: string;
-  attributes: { [s: string]: any };
+};
+
+export type HassEntity = HassEntityBase & {
+  attributes: { [key: string]: any };
 };
 
 export type HassEntities = { [entity_id: string]: HassEntity };


### PR DESCRIPTION
Splits out the event and entity types so that downstream TS consumers can easily create domain specific entity types and event type specific types.

Non-breaking change.