### PR TITLE
Allow refreshing collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ getCollection<State>(
   subscribeUpdates: (
     conn: Connection,
     store: Store<State>
-  ) => Promise<() => void>,
+  ) => Promise<UnsubscribeFunc>,
 ): Collection<State>
 
 // Returns object with following type

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ getCollection<State>(
 // Returns object with following type
 class Collection<State> {
   state: State;
-  async refresh(): Promise<State>;
+  async refresh(): Promise<void>;
   subscribe(subscriber: (state: State) => void): UnsubscribeFunc;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -204,9 +204,10 @@ getCollection<State>(
   ) => Promise<() => void>,
 ): Collection<State>
 
+// Returns object with following type
 class Collection<State> {
-  active: boolean;
-  onChange(state: State) => void;
+  state: State;
+  async refresh(): Promise<State>;
   subscribe(subscriber: (state: State) => void): UnsubscribeFunc;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The function `subscribeServices` will return an unsubscribe function.
 ```javascript
 import { subscribeServices } from "home-assistant-js-websocket";
 
-// conn
+// conn is the connection from earlier.
 subscribeServices(conn, services => console.log("New services!", services));
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,8 +150,19 @@ The function `subscribeEntities` will return an unsubscribe function.
 import { subscribeEntities } from "home-assistant-js-websocket";
 
 // conn is the connection from earlier.
-
 subscribeEntities(conn, entities => console.log("New entities!", entities));
+```
+
+You can also import the collection:
+
+```javascript
+import { entitiesColl } from "home-assistant-js-websocket";
+
+// conn is the connection from earlier.
+const coll = entitiesColl(connection);
+console.log(coll.state);
+await coll.refresh();
+coll.subscribe(entities => console.log(entities));
 ```
 
 ### Config
@@ -164,8 +175,19 @@ The function `subscribeConfig` will return an unsubscribe function.
 import { subscribeConfig } from "home-assistant-js-websocket";
 
 // conn is the connection from earlier.
-
 subscribeConfig(conn, config => console.log("New config!", config));
+```
+
+You can also import the collection:
+
+```javascript
+import { configColl } from "home-assistant-js-websocket";
+
+// conn is the connection from earlier.
+const coll = configColl(connection);
+console.log(coll.state);
+await coll.refresh();
+coll.subscribe(config => console.log(config));
 ```
 
 ### Services
@@ -177,9 +199,20 @@ The function `subscribeServices` will return an unsubscribe function.
 ```javascript
 import { subscribeServices } from "home-assistant-js-websocket";
 
-// conn is the connection from earlier.
-
+// conn
 subscribeServices(conn, services => console.log("New services!", services));
+```
+
+You can also import the collection:
+
+```javascript
+import { servicesColl } from "home-assistant-js-websocket";
+
+// conn is the connection from earlier.
+const coll = servicesColl(connection);
+console.log(coll.state);
+await coll.refresh();
+coll.subscribe(services => console.log(services));
 ```
 
 ### Collections

--- a/README.md
+++ b/README.md
@@ -269,13 +269,12 @@ const fetchPanels = conn => conn.sendMessagePromise({ type: "get_panels" });
 const subscribeUpdates = (conn, store) =>
   conn.subscribeEvents(store.action(panelRegistered), "panel_registered");
 
-const subscribePanels = (conn, onChange) =>
-  getCollection(conn, "_pnl", fetchPanels, subscribeUpdates).subscribe(
-    onChange
-  );
+const panelsColl = getCollection(conn, "_pnl", fetchPanels, subscribeUpdates);
 
 // Now use collection
-subscribePanels(conn, panels => console.log("New panels!", panels));
+console.log(panelsColl.state);
+await panelsColl.refresh();
+panelsColl.subscribe(panels => console.log("New panels!", panels));
 ```
 
 Collections are useful to define if data is needed for initial data load. You can create a collection and have code on your page call it before you start rendering the UI. By the time UI is loaded, the data will be available to use.

--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -1,77 +1,11 @@
-import { Store } from "./store";
+import { Store, createStore } from "./store";
 import { Connection } from "./connection";
 import { UnsubscribeFunc } from "./types";
 
-export class Collection<State> {
-  public active: boolean;
-  private _unsubProm?: Promise<UnsubscribeFunc>;
-  private _conn: Connection;
-  private _store: Store<State>;
-  private _fetchCollection: (conn: Connection) => Promise<State>;
-  private _subscribeUpdates: (
-    conn: Connection,
-    store: Store<State>
-  ) => Promise<UnsubscribeFunc>;
-
-  constructor(
-    conn: Connection,
-    key: string,
-    fetchCollection: (conn: Connection) => Promise<State>,
-    subscribeUpdates: (
-      conn: Connection,
-      store: Store<State>
-    ) => Promise<UnsubscribeFunc>
-  ) {
-    this.active = false;
-    this._conn = conn;
-    this._fetchCollection = fetchCollection;
-    this._subscribeUpdates = subscribeUpdates;
-    this._store = new Store<State>();
-    this.refresh = this.refresh.bind(this);
-
-    // Store for reuse
-    conn[key] = this;
-  }
-
-  async refresh() {
-    try {
-      this._store.setState(await this._fetchCollection(this._conn), true);
-    } catch (err) {
-      // Swallow errors if socket is connecting, closing or closed.
-      // We will automatically call refresh again when we re-establish the connection.
-      // Using conn.socket instead of WebSocket for better node support
-      if (this._conn.socket.readyState == this._conn.socket.OPEN) {
-        throw err;
-      }
-    }
-  }
-
-  subscribe(subscriber: (state: State) => void): UnsubscribeFunc {
-    if (!this.active) {
-      this.active = true;
-
-      // Subscribe to changes
-      this._unsubProm = this._subscribeUpdates(this._conn, this._store);
-
-      // Fetch when connection re-established.
-      this._conn.addEventListener("ready", this.refresh);
-
-      this.refresh();
-    }
-
-    this._store.subscribe(subscriber);
-
-    return () => {
-      this._store.unsubscribe(subscriber);
-      if (this._store.listeners.length === 0 && this.active) {
-        this.active = false;
-        // Unsubscribe from changes
-        if (this._unsubProm) this._unsubProm.then(unsub => unsub());
-        this._conn.removeEventListener("ready", this.refresh);
-      }
-    };
-  }
-}
+type Collection<State> = {
+  refresh(): Promise<void>;
+  subscribe(subscriber: (state: State) => void): UnsubscribeFunc;
+};
 
 export const getCollection = <State>(
   conn: Connection,
@@ -81,8 +15,59 @@ export const getCollection = <State>(
     conn: Connection,
     store: Store<State>
   ) => Promise<UnsubscribeFunc>
-): Collection<State> =>
-  conn[key] || new Collection(conn, key, fetchCollection, subscribeUpdates);
+): Collection<State> => {
+  if (conn[key]) {
+    return conn[key];
+  }
+
+  let active = 0;
+  let unsubProm: Promise<UnsubscribeFunc>;
+  let store = createStore<State>();
+
+  async function refresh() {
+    try {
+      store.setState(await fetchCollection(conn), true);
+    } catch (err) {
+      // Swallow errors if socket is connecting, closing or closed.
+      // We will automatically call refresh again when we re-establish the connection.
+      // Using conn.socket instead of WebSocket for better node support
+      if (conn.socket.readyState == conn.socket.OPEN) {
+        throw err;
+      }
+    }
+  }
+
+  conn[key] = {
+    refresh,
+    subscribe(subscriber: (state: State) => void): UnsubscribeFunc {
+      if (!active) {
+        active++;
+
+        // Subscribe to changes
+        unsubProm = subscribeUpdates(conn, store);
+
+        // Fetch when connection re-established.
+        conn.addEventListener("ready", refresh);
+
+        refresh();
+      }
+
+      const unsub = store.subscribe(subscriber);
+
+      return () => {
+        unsub();
+        active--;
+        if (!active) {
+          // Unsubscribe from changes
+          if (unsubProm) unsubProm.then(unsub => unsub());
+          conn.removeEventListener("ready", refresh);
+        }
+      };
+    }
+  };
+
+  return conn[key];
+};
 
 // Legacy name. It gets a collection and subscribes.
 export const createCollection = <State>(

--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -4,7 +4,7 @@ import { UnsubscribeFunc } from "./types";
 
 export type Collection<State> = {
   state: State;
-  refresh(): Promise<State>;
+  refresh(): Promise<void>;
   subscribe(subscriber: (state: State) => void): UnsubscribeFunc;
 };
 
@@ -25,10 +25,9 @@ export const getCollection = <State>(
   let unsubProm: Promise<UnsubscribeFunc>;
   let store = createStore<State>();
 
-  // @ts-ignore
-  async function refresh(): Promise<State> {
+  async function refresh(): Promise<void> {
     try {
-      return store.setState(await fetchCollection(conn), true);
+      store.setState(await fetchCollection(conn), true);
     } catch (err) {
       // Swallow errors if socket is connecting, closing or closed.
       // We will automatically call refresh again when we re-establish the connection.
@@ -66,7 +65,10 @@ export const getCollection = <State>(
         active--;
         if (!active) {
           // Unsubscribe from changes
-          if (unsubProm) unsubProm.then(unsub => unsub());
+          if (unsubProm)
+            unsubProm.then(unsub => {
+              unsub();
+            });
           conn.removeEventListener("ready", refresh);
         }
       };

--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -2,11 +2,90 @@ import { Store } from "./store";
 import { Connection } from "./connection";
 import { UnsubscribeFunc } from "./types";
 
-// fetchCollection returns promise that resolves to current value of collection.
-// subscribeUpdates(connection, store) returns promise that resolves
-// to an unsubscription function.
+export class Collection<State> {
+  public active: boolean;
+  private _unsubProm?: Promise<UnsubscribeFunc>;
+  private _conn: Connection;
+  private _store: Store<State>;
+  private _fetchCollection: (conn: Connection) => Promise<State>;
+  private _subscribeUpdates: (
+    conn: Connection,
+    store: Store<State>
+  ) => Promise<UnsubscribeFunc>;
 
-export function createCollection<State>(
+  constructor(
+    conn: Connection,
+    key: string,
+    fetchCollection: (conn: Connection) => Promise<State>,
+    subscribeUpdates: (
+      conn: Connection,
+      store: Store<State>
+    ) => Promise<UnsubscribeFunc>
+  ) {
+    this.active = false;
+    this._conn = conn;
+    this._fetchCollection = fetchCollection;
+    this._subscribeUpdates = subscribeUpdates;
+    this._store = new Store<State>();
+    this.refresh = this.refresh.bind(this);
+
+    // Store for reuse
+    conn[key] = this;
+  }
+
+  async refresh() {
+    try {
+      this._store.setState(await this._fetchCollection(this._conn), true);
+    } catch (err) {
+      // Swallow errors if socket is connecting, closing or closed.
+      // We will automatically call refresh again when we re-establish the connection.
+      // Using conn.socket instead of WebSocket for better node support
+      if (this._conn.socket.readyState == this._conn.socket.OPEN) {
+        throw err;
+      }
+    }
+  }
+
+  subscribe(subscriber: (state: State) => void): UnsubscribeFunc {
+    if (!this.active) {
+      this.active = true;
+
+      // Subscribe to changes
+      this._unsubProm = this._subscribeUpdates(this._conn, this._store);
+
+      // Fetch when connection re-established.
+      this._conn.addEventListener("ready", this.refresh);
+
+      this.refresh();
+    }
+
+    this._store.subscribe(subscriber);
+
+    return () => {
+      this._store.unsubscribe(subscriber);
+      if (this._store.listeners.length === 0 && this.active) {
+        this.active = false;
+        // Unsubscribe from changes
+        if (this._unsubProm) this._unsubProm.then(unsub => unsub());
+        this._conn.removeEventListener("ready", this.refresh);
+      }
+    };
+  }
+}
+
+export const getCollection = <State>(
+  conn: Connection,
+  key: string,
+  fetchCollection: (conn: Connection) => Promise<State>,
+  subscribeUpdates: (
+    conn: Connection,
+    store: Store<State>
+  ) => Promise<UnsubscribeFunc>
+): Collection<State> =>
+  conn[key] || new Collection(conn, key, fetchCollection, subscribeUpdates);
+
+// Legacy name. It gets a collection and subscribes.
+export const createCollection = <State>(
   key: string,
   fetchCollection: (conn: Connection) => Promise<State>,
   subscribeUpdates: (
@@ -15,43 +94,7 @@ export function createCollection<State>(
   ) => Promise<UnsubscribeFunc>,
   conn: Connection,
   onChange: (state: State) => void
-): UnsubscribeFunc {
-  if (key in conn) {
-    return conn[key](onChange);
-  }
-
-  let unsubProm: Promise<UnsubscribeFunc>;
-
-  const store = new Store<State>(() => {
-    if (unsubProm) unsubProm.then(unsub => unsub());
-    conn.removeEventListener("ready", refresh);
-    delete conn[key];
-  });
-
-  conn[key] = (onChange: (state: State) => void) => store.subscribe(onChange);
-
-  // Subscribe to changes
-  if (subscribeUpdates) {
-    unsubProm = subscribeUpdates(conn, store);
-  }
-
-  const refresh = async () => {
-    try {
-      store.setState(await fetchCollection(conn), true);
-    } catch (err) {
-      // Swallow errors if socket is connecting, closing or closed.
-      // We will automatically call refresh again when we re-establish the connection.
-      // Using conn.socket instead of WebSocket for better node support
-      if (conn.socket.readyState == conn.socket.OPEN) {
-        throw err;
-      }
-    }
-  };
-
-  // Fetch when connection re-established.
-  conn.addEventListener("ready", refresh);
-
-  refresh();
-
-  return store.subscribe(onChange);
-}
+): UnsubscribeFunc =>
+  getCollection(conn, key, fetchCollection, subscribeUpdates).subscribe(
+    onChange
+  );

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,4 +1,4 @@
-import { createCollection } from "./collection";
+import { getCollection } from "./collection";
 import { HassConfig, UnsubscribeFunc } from "./types";
 import { Connection } from "./connection";
 import { Store } from "./store";
@@ -28,14 +28,14 @@ const subscribeUpdates = (conn: Connection, store: Store<HassConfig>) =>
     "component_loaded"
   );
 
+const coll = (conn: Connection) =>
+  getCollection(conn, "_cnf", fetchConfig, subscribeUpdates);
+
+export const refreshConfig = (conn: Connection): void => {
+  coll(conn).refresh();
+};
+
 export const subscribeConfig = (
   conn: Connection,
   onChange: (state: HassConfig) => void
-): UnsubscribeFunc =>
-  createCollection<HassConfig>(
-    "_cnf",
-    fetchConfig,
-    subscribeUpdates,
-    conn,
-    onChange
-  );
+): UnsubscribeFunc => coll(conn).subscribe(onChange);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -28,14 +28,10 @@ const subscribeUpdates = (conn: Connection, store: Store<HassConfig>) =>
     "component_loaded"
   );
 
-const coll = (conn: Connection) =>
+const ConfigColl = (conn: Connection) =>
   getCollection(conn, "_cnf", fetchConfig, subscribeUpdates);
-
-export const refreshConfig = (conn: Connection): void => {
-  coll(conn).refresh();
-};
 
 export const subscribeConfig = (
   conn: Connection,
   onChange: (state: HassConfig) => void
-): UnsubscribeFunc => coll(conn).subscribe(onChange);
+): UnsubscribeFunc => ConfigColl(conn).subscribe(onChange);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -28,10 +28,10 @@ const subscribeUpdates = (conn: Connection, store: Store<HassConfig>) =>
     "component_loaded"
   );
 
-const ConfigColl = (conn: Connection) =>
+const configColl = (conn: Connection) =>
   getCollection(conn, "_cnf", fetchConfig, subscribeUpdates);
 
 export const subscribeConfig = (
   conn: Connection,
   onChange: (state: HassConfig) => void
-): UnsubscribeFunc => ConfigColl(conn).subscribe(onChange);
+): UnsubscribeFunc => configColl(conn).subscribe(onChange);

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -34,14 +34,10 @@ const subscribeUpdates = (conn: Connection, store: Store<HassEntities>) =>
     "state_changed"
   );
 
-const coll = (conn: Connection) =>
+export const EntitiesColl = (conn: Connection) =>
   getCollection(conn, "_ent", fetchEntities, subscribeUpdates);
-
-export const refreshEntities = (conn: Connection): void => {
-  coll(conn).refresh();
-};
 
 export const subscribeEntities = (
   conn: Connection,
   onChange: (state: HassEntities) => void
-): UnsubscribeFunc => coll(conn).subscribe(onChange);
+): UnsubscribeFunc => EntitiesColl(conn).subscribe(onChange);

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -34,10 +34,10 @@ const subscribeUpdates = (conn: Connection, store: Store<HassEntities>) =>
     "state_changed"
   );
 
-export const EntitiesColl = (conn: Connection) =>
+export const entitiesColl = (conn: Connection) =>
   getCollection(conn, "_ent", fetchEntities, subscribeUpdates);
 
 export const subscribeEntities = (
   conn: Connection,
   onChange: (state: HassEntities) => void
-): UnsubscribeFunc => EntitiesColl(conn).subscribe(onChange);
+): UnsubscribeFunc => entitiesColl(conn).subscribe(onChange);

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -1,4 +1,4 @@
-import { createCollection } from "./collection";
+import { getCollection } from "./collection";
 import { HassEntities, StateChangedEvent, UnsubscribeFunc } from "./types";
 import { Connection } from "./connection";
 import { Store } from "./store";
@@ -34,14 +34,14 @@ const subscribeUpdates = (conn: Connection, store: Store<HassEntities>) =>
     "state_changed"
   );
 
+const coll = (conn: Connection) =>
+  getCollection(conn, "_ent", fetchEntities, subscribeUpdates);
+
+export const refreshEntities = (conn: Connection): void => {
+  coll(conn).refresh();
+};
+
 export const subscribeEntities = (
   conn: Connection,
   onChange: (state: HassEntities) => void
-): UnsubscribeFunc =>
-  createCollection<HassEntities>(
-    "_ent",
-    fetchEntities,
-    subscribeUpdates,
-    conn,
-    onChange
-  );
+): UnsubscribeFunc => coll(conn).subscribe(onChange);

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -65,14 +65,10 @@ const subscribeUpdates = (conn: Connection, store: Store<HassServices>) =>
     )
   ]).then(unsubs => () => unsubs.forEach(fn => fn()));
 
-const coll = (conn: Connection) =>
+const ServicesColl = (conn: Connection) =>
   getCollection(conn, "_srv", fetchServices, subscribeUpdates);
-
-export const refreshServices = (conn: Connection): void => {
-  coll(conn).refresh();
-};
 
 export const subscribeServices = (
   conn: Connection,
   onChange: (state: HassServices) => void
-): UnsubscribeFunc => coll(conn).subscribe(onChange);
+): UnsubscribeFunc => ServicesColl(conn).subscribe(onChange);

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -65,10 +65,10 @@ const subscribeUpdates = (conn: Connection, store: Store<HassServices>) =>
     )
   ]).then(unsubs => () => unsubs.forEach(fn => fn()));
 
-const ServicesColl = (conn: Connection) =>
+const servicesColl = (conn: Connection) =>
   getCollection(conn, "_srv", fetchServices, subscribeUpdates);
 
 export const subscribeServices = (
   conn: Connection,
   onChange: (state: HassServices) => void
-): UnsubscribeFunc => ServicesColl(conn).subscribe(onChange);
+): UnsubscribeFunc => servicesColl(conn).subscribe(onChange);

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -1,4 +1,4 @@
-import { createCollection } from "./collection";
+import { getCollection } from "./collection";
 import { HassServices, HassDomainServices, UnsubscribeFunc } from "./types";
 import { Connection } from "./connection";
 import { Store } from "./store";
@@ -65,14 +65,14 @@ const subscribeUpdates = (conn: Connection, store: Store<HassServices>) =>
     )
   ]).then(unsubs => () => unsubs.forEach(fn => fn()));
 
+const coll = (conn: Connection) =>
+  getCollection(conn, "_srv", fetchServices, subscribeUpdates);
+
+export const refreshServices = (conn: Connection): void => {
+  coll(conn).refresh();
+};
+
 export const subscribeServices = (
   conn: Connection,
   onChange: (state: HassServices) => void
-): UnsubscribeFunc =>
-  createCollection<HassServices>(
-    "_srv",
-    fetchServices,
-    subscribeUpdates,
-    conn,
-    onChange
-  );
+): UnsubscribeFunc => coll(conn).subscribe(onChange);

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -9,12 +9,12 @@ type Action<State> = (
   state: State,
   ...args: any[]
 ) => Partial<State> | Promise<Partial<State>> | null;
-type BoundAction<State> = (...args: any[]) => State | Promise<State>;
+type BoundAction<State> = (...args: any[]) => void;
 
 export type Store<State> = {
   state: State | undefined;
   action(action: Action<State>): BoundAction<State>;
-  setState(update: Partial<State>, overwrite?: boolean): State;
+  setState(update: Partial<State>, overwrite?: boolean): void;
   subscribe(listener: Listener<State>): UnsubscribeFunc;
 };
 
@@ -33,13 +33,12 @@ export const createStore = <State>(state?: State): Store<State> => {
     listeners = out;
   }
 
-  function setState(update: Partial<State>, overwrite: boolean): State {
+  function setState(update: Partial<State>, overwrite: boolean): void {
     state = overwrite ? (update as State) : Object.assign({}, state, update);
     let currentListeners = listeners;
     for (let i = 0; i < currentListeners.length; i++) {
       currentListeners[i](state);
     }
-    return state;
   }
 
   /**
@@ -61,7 +60,7 @@ export const createStore = <State>(state?: State): Store<State> => {
      */
     action(action: Action<State>): BoundAction<State> {
       function apply(result: Partial<State>) {
-        return setState(result, false);
+        setState(result, false);
       }
 
       // Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -14,7 +14,7 @@ type BoundAction<State> = (...args: any[]) => State | Promise<State>;
 export type Store<State> = {
   state: State | undefined;
   action(action: Action<State>): BoundAction<State>;
-  setState(update: Partial<State>, overwrite?: boolean): void;
+  setState(update: Partial<State>, overwrite?: boolean): State;
   subscribe(listener: Listener<State>): UnsubscribeFunc;
 };
 
@@ -33,11 +33,13 @@ export const createStore = <State>(state?: State): Store<State> => {
     listeners = out;
   }
 
-  function setState(update: Partial<State>, overwrite: boolean) {
+  function setState(update: Partial<State>, overwrite: boolean): State {
     state = overwrite ? (update as State) : Object.assign({}, state, update);
     let currentListeners = listeners;
-    for (let i = 0; i < currentListeners.length; i++)
+    for (let i = 0; i < currentListeners.length; i++) {
       currentListeners[i](state);
+    }
+    return state;
   }
 
   /**
@@ -59,7 +61,7 @@ export const createStore = <State>(state?: State): Store<State> => {
      */
     action(action: Action<State>): BoundAction<State> {
       function apply(result: Partial<State>) {
-        setState(result, false);
+        return setState(result, false);
       }
 
       // Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -5,15 +5,12 @@ import { UnsubscribeFunc } from "./types";
 // And then adopted to our needs + typescript
 
 type Listener<State> = (state: State) => void;
-type NoSubscribersCallback = () => void;
 
 export class Store<State> {
-  private _noSub: NoSubscribersCallback;
   listeners: Listener<State>[];
   state: State | undefined;
 
-  constructor(noSubscriptions: NoSubscribersCallback) {
-    this._noSub = noSubscriptions;
+  constructor() {
     this.listeners = [];
   }
 
@@ -81,8 +78,5 @@ export class Store<State> {
       }
     }
     this.listeners = out;
-    if (out.length === 0) {
-      this._noSub();
-    }
   }
 }

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -5,78 +5,100 @@ import { UnsubscribeFunc } from "./types";
 // And then adopted to our needs + typescript
 
 type Listener<State> = (state: State) => void;
+type Action<State> = (
+  state: State,
+  ...args: any[]
+) => Partial<State> | Promise<Partial<State>> | null;
+type BoundAction<State> = (...args: any[]) => State | Promise<State>;
 
-export class Store<State> {
-  listeners: Listener<State>[];
+export type Store<State> = {
   state: State | undefined;
+  action(action: Action<State>): BoundAction<State>;
+  setState(update: Partial<State>, overwrite?: boolean): void;
+  subscribe(listener: Listener<State>): UnsubscribeFunc;
+};
 
-  constructor() {
-    this.listeners = [];
-  }
+export const createStore = <State>(state?: State): Store<State> => {
+  let listeners: Listener<State>[] = [];
 
-  /**
-   * Create a bound copy of the given action function.
-   * The bound returned function invokes action() and persists the result back to the store.
-   * If the return value of `action` is a Promise, the resolved value will be used as state.
-   * @param {Function} action An action of the form `action(state, ...args) -> stateUpdate`
-   * @returns {Function} boundAction()
-   */
-  action(
-    action: (
-      state: State,
-      ...args: any[]
-    ) => Partial<State> | Promise<Partial<State>> | null
-  ) {
-    const apply = (result: Partial<State>) => this.setState(result, false);
-
-    // Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500
-    return (...args: any[]) => {
-      const ret = action(this.state as State, ...args);
-      if (ret != null) {
-        return "then" in ret ? ret.then(apply) : apply(ret);
-      }
-    };
-  }
-
-  setState(update: Partial<State>, overwrite?: boolean) {
-    this.state = overwrite
-      ? (update as State)
-      : Object.assign({}, this.state, update);
-    const currentListeners = this.listeners;
-    for (let i = 0; i < currentListeners.length; i++) {
-      currentListeners[i](this.state);
-    }
-  }
-
-  /**
-   * Register a listener function to be called whenever state is changed. Returns an `unsubscribe()` function.
-   * @param {Function} listener A function to call when state changes. Gets passed the new state.
-   * @returns {Function} unsubscribe()
-   */
-  subscribe(listener: Listener<State>): UnsubscribeFunc {
-    this.listeners.push(listener);
-    if (this.state !== undefined) listener(this.state);
-    return () => {
-      this.unsubscribe(listener);
-    };
-  }
-
-  /**
-   * Remove a previously-registered listener function.
-   * @param {Function} listener The callback previously passed to `subscribe()` that should be removed.
-   * @function
-   */
-  unsubscribe(listener: Listener<State>) {
-    let toFind: Listener<State> | null = listener;
-    const out = [];
-    const listeners = this.listeners;
+  function unsubscribe(listener: Listener<State> | null) {
+    let out = [];
     for (let i = 0; i < listeners.length; i++) {
-      if (listeners[i] === toFind) {
-        toFind = null;
+      if (listeners[i] === listener) {
+        listener = null;
       } else {
         out.push(listeners[i]);
       }
     }
-    this.listeners = out;
+    listeners = out;
   }
-}
+
+  function setState(update: Partial<State>, overwrite: boolean) {
+    state = overwrite ? (update as State) : Object.assign({}, state, update);
+    let currentListeners = listeners;
+    for (let i = 0; i < currentListeners.length; i++)
+      currentListeners[i](state);
+  }
+
+  /**
+   * An observable state container, returned from {@link createStore}
+   * @name store
+   */
+
+  return {
+    get state() {
+      return state;
+    },
+
+    /**
+     * Create a bound copy of the given action function.
+     * The bound returned function invokes action() and persists the result back to the store.
+     * If the return value of `action` is a Promise, the resolved value will be used as state.
+     * @param {Function} action	An action of the form `action(state, ...args) -> stateUpdate`
+     * @returns {Function} boundAction()
+     */
+    action(action: Action<State>): BoundAction<State> {
+      function apply(result: Partial<State>) {
+        setState(result, false);
+      }
+
+      // Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500
+      return function() {
+        let args = [state];
+        for (let i = 0; i < arguments.length; i++) args.push(arguments[i]);
+        // @ts-ignore
+        let ret = action.apply(this, args);
+        if (ret != null) {
+          if (ret.then) return ret.then(apply);
+          return apply(ret);
+        }
+      };
+    },
+
+    /**
+     * Apply a partial state object to the current state, invoking registered listeners.
+     * @param {Object} update				An object with properties to be merged into state
+     * @param {Boolean} [overwrite=false]	If `true`, update will replace state instead of being merged into it
+     */
+    setState,
+
+    /**
+     * Register a listener function to be called whenever state is changed. Returns an `unsubscribe()` function.
+     * @param {Function} listener	A function to call when state changes. Gets passed the new state.
+     * @returns {Function} unsubscribe()
+     */
+    subscribe(listener: Listener<State>) {
+      listeners.push(listener);
+      return () => {
+        unsubscribe(listener);
+      };
+    }
+
+    // /**
+    //  * Remove a previously-registered listener function.
+    //  * @param {Function} listener	The callback previously passed to `subscribe()` that should be removed.
+    //  * @function
+    //  */
+    // unsubscribe,
+  };
+};


### PR DESCRIPTION
This updates the code to allow refreshing collections. It does so by exposing a new Collection class that one can subscribe to and refresh.

The old `createCollection` method is deprecated in favor of the new `getCollection`.

Fixes #51 
