### PR TITLE
Allow subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a websocket client written in JavaScript that allows retrieving authenti
 Check [the demo](https://hass-auth-demo.glitch.me/). The repository also includes an [example client](https://github.com/home-assistant/home-assistant-js-websocket/blob/master/example.html):
 
 Clone this repository, then go to home-assistant-js-websocket folder and run the following commands:
+
 ```bash
 yarn install
 yarn build
@@ -291,6 +292,10 @@ Subscribe to all or specific events on the Home Assistant bus. Calls `eventCallb
 
 Returns a promise that will resolve to a function that will cancel the subscription once called.
 
+Subscription will be automatically re-established after a reconnect.
+
+Uses `conn.subscribeMessage` under the hood.
+
 ##### `conn.addEventListener(eventType, listener)`
 
 Listen for events on the connection. [See docs.](#automatic-reconnecting)
@@ -298,6 +303,14 @@ Listen for events on the connection. [See docs.](#automatic-reconnecting)
 ##### `conn.sendMessagePromise(message)`
 
 Send a message to the server. Returns a promise that resolves or rejects based on the result of the server. Special case rejection is `ERR_CONNECTION_LOST` if the connection is lost while the command is in progress.
+
+##### `conn.subscribeMessage(callback, subscribeMessage)`
+
+Call an endpoint in Home Assistant that creates a subscription. Calls `callback` for each item that gets received.
+
+Returns a promise that will resolve to a function that will cancel the subscription once called.
+
+Subscription will be automatically re-established after a reconnect.
 
 ## Auth API Reference
 

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -118,7 +118,7 @@ export class Connection {
           info.subscribe().then(unsub => {
             info.unsubscribe = unsub;
             // We need to resolve this in case it wasn't resolved yet.
-            // This allows us to call subscribeEvents while we're disconnected
+            // This allows us to subscribe while we're disconnected
             // and recover properly.
             info.resolve();
           });
@@ -164,8 +164,13 @@ export class Connection {
     this.socket.close();
   }
 
-  // callback will be called when a new event fires
-  // Returned promise resolves to an unsubscribe function.
+  /**
+   * Subscribe to a specific or all events.
+   *
+   * @param callback Callback  to be called when a new event fires
+   * @param eventType
+   * @returns promise that resolves to an unsubscribe function
+   */
   async subscribeEvents<EventType>(
     callback: (ev: EventType) => void,
     eventType?: string
@@ -202,7 +207,8 @@ export class Connection {
    * Call a websocket command that starts a subscription on the backend.
    *
    * @param message the message to start the subscription
-   * @param callback the callback to be called with subscription items
+   * @param callback the callback to be called when a new item arrives
+   * @returns promise that resolves to an unsubscribe function
    */
   async subscribeMessage<Result>(
     callback: (result: Result) => void,

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -6,7 +6,7 @@ import * as messages from "./messages";
 import { ERR_INVALID_AUTH, ERR_CONNECTION_LOST } from "./errors";
 import { ConnectionOptions, HassEvent, MessageBase } from "./types";
 
-const DEBUG = true;
+const DEBUG = false;
 
 export type ConnectionEventListener = (
   conn: Connection,


### PR DESCRIPTION
Generalize the subscribeEvents logic so it can be re-used by any backend command that wants to offer subscriptions by the frontend that don't rely on events.

Function `subscribeEvents` now re-uses `subscribeMessage` under the hood.

To subscribe to another endpoint:

```js
// Returns promise that resolves to unsubscribe function.
connection.subscribeMessage(
  (msg) => console.log("Received", msg),
  {type: 'mqtt/subscribe', topic: 'paulus/test' }
)
```