### PR TITLE
Allow passing in WebSocket constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ createConnection({ auth });
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | auth         | Auth object to use to create a connection.                                                                                                     |
 | createSocket | Override the createSocket method with your own. `(options) => Promise<WebSocket>`. Needs to return a connection that is already authenticated. |
+| WebSocket    | Constructor to use to initialize the WebSocket connection inside the built-in createSocket method.                                             |
 | setupRetry   | Number of times to retry initial connection when it fails. Set to -1 for infinite retries. Default is 0 (no retries)                           |
 
 Currently the following error codes can be raised by createConnection:
@@ -371,20 +372,12 @@ import {
 
 ## Using this in NodeJS
 
-To use this package in NodeJS, you will want to define your own `createSocket` method for `createConnection` to use. Your createSocket function will need to set up the web socket connection with Home Assistant and handle the auth.
+NodeJS does not have a WebSocket client built-in, but there are some good ones on NPM. We recommend `ws`. You can pass the WebSocket constructor to use as part of the options.
 
 ```js
 const WebSocket = require("ws");
 
 createConnection({
-  createSocket() {
-    // Open connection
-    const ws = new WebSocket("ws://localhost:8123");
-
-    // Functions to handle authentication with Home Assistant
-    // Implement yourself :)
-
-    return ws;
-  }
+  WebSocket
 });
 ```

--- a/example.html
+++ b/example.html
@@ -1,72 +1,83 @@
 <html>
-<!-- To try locally, run: `yarn build` and then `npx http-server -o` -->
+  <!-- To try locally, run: `yarn build` and then `npx http-server -o` -->
 
-<body>
-  <table>
-    <tbody>
+  <body>
+    <table>
+      <tbody></tbody>
+    </table>
+    <script type="module">
+      import {
+        getAuth,
+        getUser,
+        callService,
+        createConnection,
+        subscribeEntities,
+        ERR_HASS_HOST_REQUIRED
+      } from "./dist/haws.es.js";
 
-    </tbody>
-  </table>
-  <script type='module'>
-    import {
-      getAuth,
-      getUser,
-      callService,
-      createConnection,
-      subscribeEntities,
-      ERR_HASS_HOST_REQUIRED,
-    } from './dist/haws.es.js';
-
-    (async () => {
-      let auth;
-      try {
-        auth = await getAuth();
-      } catch (err) {
-        if (err === ERR_HASS_HOST_REQUIRED) {
-          const hassUrl = prompt("What host to connect to?", "http://localhost:8123");
-          if (!hassUrl) return;
-          auth = await getAuth({ hassUrl });
-        } else {
-          alert(`Unknown error: ${err}`);
-          return;
+      (async () => {
+        let auth;
+        try {
+          auth = await getAuth();
+        } catch (err) {
+          if (err === ERR_HASS_HOST_REQUIRED) {
+            const hassUrl = prompt(
+              "What host to connect to?",
+              "http://localhost:8123"
+            );
+            if (!hassUrl) return;
+            auth = await getAuth({ hassUrl });
+          } else {
+            alert(`Unknown error: ${err}`);
+            return;
+          }
         }
+        const connection = await createConnection({ auth });
+        subscribeEntities(connection, entities =>
+          renderEntities(connection, entities)
+        );
+
+        // To play from the console
+        window.auth = auth;
+        window.connection = connection;
+        getUser(connection).then(user => console.log("Logged in as", user));
+      })();
+
+      function renderEntities(connection, entities) {
+        const root = document.querySelector("tbody");
+        while (root.lastChild) root.removeChild(root.lastChild);
+
+        Object.keys(entities)
+          .sort()
+          .forEach(entId => {
+            const tr = document.createElement("tr");
+
+            const tdName = document.createElement("td");
+            tdName.innerHTML = entId;
+            tr.appendChild(tdName);
+
+            const tdState = document.createElement("td");
+            const text = document.createTextNode(entities[entId].state);
+            tdState.appendChild(text);
+
+            if (
+              ["switch", "light", "input_boolean"].includes(
+                entId.split(".", 1)[0]
+              )
+            ) {
+              const button = document.createElement("button");
+              button.innerHTML = "toggle";
+              button.onclick = () =>
+                callService(connection, "homeassistant", "toggle", {
+                  entity_id: entId
+                });
+              tdState.appendChild(button);
+            }
+            tr.appendChild(tdState);
+
+            root.appendChild(tr);
+          });
       }
-      const connection = await createConnection({ auth });
-      subscribeEntities(connection, entities => renderEntities(connection, entities));
-
-      // To play from the console
-      window.auth = auth;
-      window.connection = connection;
-      getUser(connection).then(user => console.log("Logged in as", user));
-    })();
-
-    function renderEntities(connection, entities) {
-      const root = document.querySelector('tbody');
-      while (root.lastChild) root.removeChild(root.lastChild);
-
-      Object.keys(entities).sort().forEach((entId) => {
-        const tr = document.createElement('tr');
-
-        const tdName = document.createElement('td');
-        tdName.innerHTML = entId;
-        tr.appendChild(tdName);
-
-        const tdState = document.createElement('td');
-        const text = document.createTextNode(entities[entId].state);
-        tdState.appendChild(text);
-
-        if (['switch', 'light', 'input_boolean'].includes(entId.split('.', 1)[0])) {
-          const button = document.createElement('button');
-          button.innerHTML = 'toggle';
-          button.onclick = () => callService(connection, 'homeassistant', 'toggle', { entity_id: entId });
-          tdState.appendChild(button);
-        }
-        tr.appendChild(tdState);
-
-        root.appendChild(tr);
-      });
-    }
-  </script>
-</body>
-
+    </script>
+  </body>
 </html>

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -20,6 +20,7 @@ export function createSocket(options: ConnectionOptions): Promise<WebSocket> {
     throw ERR_HASS_HOST_REQUIRED;
   }
   const auth = options.auth;
+  const wsConstructor = options.WebSocket || WebSocket;
 
   // Convert from http:// -> ws://, https:// -> wss://
   const url = auth.wsUrl;
@@ -37,7 +38,7 @@ export function createSocket(options: ConnectionOptions): Promise<WebSocket> {
       console.log("[Auth Phase] New connection", url);
     }
 
-    const socket = new WebSocket(url);
+    const socket = new wsConstructor(url);
 
     // If invalid auth, we will not try to reconnect.
     let invalidAuth = false;

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -38,6 +38,7 @@ export function createSocket(options: ConnectionOptions): Promise<WebSocket> {
       console.log("[Auth Phase] New connection", url);
     }
 
+    // @ts-ignore
     const socket = new wsConstructor(url);
 
     // If invalid auth, we will not try to reconnect.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,9 @@
 import { Auth } from "./auth";
 
+type Constructor<T> = {
+  new (...args: unknown[]): T;
+};
+
 export type Error = 1 | 2 | 3 | 4;
 
 export type UnsubscribeFunc = () => void;
@@ -8,6 +12,7 @@ export type ConnectionOptions = {
   setupRetry: number;
   auth?: Auth;
   createSocket: (options: ConnectionOptions) => Promise<WebSocket>;
+  WebSocket?: Constructor<WebSocket>;
 };
 
 export type MessageBase = {


### PR DESCRIPTION
This allows passing in the WebSocket constructor to the `createConnection` method so that it's no longer needed to change `global` in NodeJS or to copy/paste `socket.ts`.

CC @keesschollaart81 @zachowj