### PR TITLE
Error handling in Auth phase

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -2,3 +2,4 @@ export const ERR_CANNOT_CONNECT = 1;
 export const ERR_INVALID_AUTH = 2;
 export const ERR_CONNECTION_LOST = 3;
 export const ERR_HASS_HOST_REQUIRED = 4;
+export const ERR_WEBSOCKET_ERROR = 5;

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -66,7 +66,7 @@ export function createSocket(options: ConnectionOptions): Promise<WebSocket> {
         return;
       }
 
-      if (args.error){
+      if (args && args.error){
         console.error("[Auth phase] Error", args.error);
         promReject(ERR_WEBSOCKET_ERROR);
         return;

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -53,7 +53,7 @@ export function createSocket(options: ConnectionOptions): Promise<WebSocket> {
     }
 
     // @ts-ignore
-    const socket = new wsConstructor(url, options.websocketOptions);
+    const socket = new wsConstructor(url);
 
     // If invalid auth, we will not try to reconnect.
     let invalidAuth = false;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,7 +13,6 @@ export type ConnectionOptions = {
   auth?: Auth;
   createSocket: (options: ConnectionOptions) => Promise<WebSocket>;
   WebSocket?: Constructor<WebSocket>;
-  websocketOptions?: any;
 };
 
 export type MessageBase = {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,7 +4,7 @@ type Constructor<T> = {
   new (...args: unknown[]): T;
 };
 
-export type Error = 1 | 2 | 3 | 4;
+export type Error = 1 | 2 | 3 | 4 | 5;
 
 export type UnsubscribeFunc = () => void;
 
@@ -13,6 +13,7 @@ export type ConnectionOptions = {
   auth?: Auth;
   createSocket: (options: ConnectionOptions) => Promise<WebSocket>;
   WebSocket?: Constructor<WebSocket>;
+  websocketOptions?: any;
 };
 
 export type MessageBase = {


### PR DESCRIPTION
I'm using this library as part of the Home Assistant VS Code extension, I use [ws](https://github.com/websockets/ws) for the WebSocket transport. By default, when setting up a WebSocket via `ws`, you cannot connect over SSL (WSS) when the certificate is not valid. 

In the context of the HA VS Code Extension, I would like to allow connections over an insecure transport by providing [ClientOptions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/ws/index.d.ts#L125) (which has a rejectUnauthorized property) to the websocket constructor. [[related issue](https://github.com/keesschollaart81/vscode-home-assistant/issues/7)].

Next to that, I added some logging during the auth phase so that if errors like this occur, it's easier to see what's going on.