### PR TITLE
Override using function instead of constructor [breaking change]

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,12 +372,12 @@ import {
 
 ## Using this in NodeJS
 
-NodeJS does not have a WebSocket client built-in, but there are some good ones on NPM. We recommend `ws`. You can pass the WebSocket constructor to use as part of the options.
+To use this library under NodeJS, you will have to use the `ws` package from NPM. You then have to pass your own WebSocket constructor as part of the connection options.
 
 ```js
 const WebSocket = require("ws");
 
 createConnection({
-  WebSocket
+  constructWebSocket: url => new WebSocket(url)
 });
 ```

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -20,7 +20,6 @@ export function createSocket(options: ConnectionOptions): Promise<WebSocket> {
     throw ERR_HASS_HOST_REQUIRED;
   }
   const auth = options.auth;
-  const wsConstructor = options.WebSocket || WebSocket;
 
   // Start refreshing expired tokens even before the WS connection is open.
   // We know that we will need auth anyway.
@@ -51,8 +50,9 @@ export function createSocket(options: ConnectionOptions): Promise<WebSocket> {
       console.log("[Auth Phase] New connection", url);
     }
 
-    // @ts-ignore
-    const socket = new wsConstructor(url);
+    const socket = options.constructWebSocket
+      ? options.constructWebSocket(url)
+      : new WebSocket(url);
 
     // If invalid auth, we will not try to reconnect.
     let invalidAuth = false;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,9 +1,5 @@
 import { Auth } from "./auth";
 
-type Constructor<T> = {
-  new (...args: unknown[]): T;
-};
-
 export type Error = 1 | 2 | 3 | 4;
 
 export type UnsubscribeFunc = () => void;
@@ -12,7 +8,7 @@ export type ConnectionOptions = {
   setupRetry: number;
   auth?: Auth;
   createSocket: (options: ConnectionOptions) => Promise<WebSocket>;
-  WebSocket?: Constructor<WebSocket>;
+  constructWebSocket?: (url: string) => WebSocket;
 };
 
 export type MessageBase = {


### PR DESCRIPTION
In #87 we introduced passing the WebSocket constructor to use as part of the connection The WebSocket constructor in NodeJS allows for more options than its browser equivalent, like disabling cert validation. By moving from passing the constructor to a constructing function, we will make it easier to allow passing other options to the WebSocket in NodeJS.

```ts
const WebSocket = require("ws");
const options = getWebSocketOptions();
createConnection({
  constructWebSocket: url => new WebSocket(url, options)
});
```

CC @keesschollaart81 @zachowj