### PR TITLE
Add rich errors [breaking change]

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ async function connect() {
     // Try to pick up authentication after user logs in
     auth = await getAuth();
   } catch (err) {
-    if (err === ERR_HASS_HOST_REQUIRED) {
+    if (err.code === ERR_HASS_HOST_REQUIRED) {
       const hassUrl = prompt(
         "What host to connect to?",
         "http://localhost:8123"
@@ -42,7 +42,7 @@ async function connect() {
       // Redirect user to log in on their instance
       auth = await getAuth({ hassUrl });
     } else {
-      alert(`Unknown error: ${err}`);
+      alert(`Unknown error: ${err.code}`);
       return;
     }
   }
@@ -71,7 +71,7 @@ getAuth({ hassUrl: "http://localhost:8123" });
 | saveTokens  | Function to store an object containing the token information.                                                                                                                                            |
 | loadTokens  | Function that returns a promise that resolves to previously stored token information object or undefined if no info available.                                                                           |
 
-In certain instances `getAuth` will raise an error. These errors can be imported from the package:
+In certain instances `getAuth` will raise an error. Each error raised by Home Assistant JS Websocket will have a `code` property that describes the error that happened. The error codes can be imported from the package:
 
 ```js
 // When bundling your application
@@ -105,7 +105,7 @@ createConnection({ auth });
 | WebSocket    | Constructor to use to initialize the WebSocket connection inside the built-in createSocket method.                                             |
 | setupRetry   | Number of times to retry initial connection when it fails. Set to -1 for infinite retries. Default is 0 (no retries)                           |
 
-Currently the following error codes can be raised by createConnection:
+When an error happens, `createConnection` will raise an error. The error will have a `code` property to describe what went wrong. The following error codes can happen:
 
 | Error              | Description                                               |
 | ------------------ | --------------------------------------------------------- |
@@ -329,7 +329,7 @@ Fetches a new access token from the server.
 
 Makes a request to the server to revoke the refresh and all related access token. Returns a promise that resolves when the request is finished.
 
-**Note:** If you support storing and retrieving tokens, the returned auth object might load tokens from your cache that are no longer valid. If this happens, the promise returned by `createConnection` will reject with `ERR_INVALID_AUTH`. If that happens, clear your tokens with `storeTokens(null`) and call `getAuth` again. This will pick up the auth flow without relying on stored tokens.
+**Note:** If you support storing and retrieving tokens, the returned auth object might load tokens from your cache that are no longer valid. If this happens, the promise returned by `createConnection` will reject with error code `ERR_INVALID_AUTH`. If that happens, clear your tokens with `storeTokens(null`) and call `getAuth` again. This will pick up the auth flow without relying on stored tokens.
 
 ## Other methods
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,12 @@ import {
 HAWS.ERR_HASS_HOST_REQUIRED;
 ```
 
-| Error                    | Description                                                                                                                                                    |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ERR_HASS_HOST_REQUIRED` | You need to pass in `hassUrl` to `getAuth` to continue getting auth. This option is not needed when the user is redirected back after successfully logging in. |
-| `ERR_INVALID_AUTH`       | This error will be raised if the url contains an authorization code that is no longer valid.                                                                   |
-| Other errors             | Unknown error!                                                                                                                                                 |
+| Error                     | Description                                                                                                                                                    |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ERR_HASS_HOST_REQUIRED`  | You need to pass in `hassUrl` to `getAuth` to continue getting auth. This option is not needed when the user is redirected back after successfully logging in. |
+| `ERR_INVALID_AUTH`        | This error will be raised if the url contains an authorization code that is no longer valid.                                                                   |
+| `ERR_CANNOT_FETCH_TOKENS` | The request to fetch tokens failed.                                                                                                                            |
+| Other errors              | Unknown error!                                                                                                                                                 |
 
 ### `createConnection()`
 

--- a/example.html
+++ b/example.html
@@ -20,7 +20,7 @@
         try {
           auth = await getAuth();
         } catch (err) {
-          if (err === ERR_HASS_HOST_REQUIRED) {
+          if (err.code === ERR_HASS_HOST_REQUIRED) {
             const hassUrl = prompt(
               "What host to connect to?",
               "http://localhost:8123"

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,10 @@
 import { parseQuery } from "./util";
-import { ERR_HASS_HOST_REQUIRED, ERR_INVALID_AUTH } from "./errors";
+import {
+  ERR_HASS_HOST_REQUIRED,
+  ERR_INVALID_AUTH,
+  HAWSError,
+  ERR_CANNOT_FETCH_TOKENS
+} from "./errors";
 
 export type AuthData = {
   hassUrl: string;
@@ -108,10 +113,12 @@ async function tokenRequest(
   });
 
   if (!resp.ok) {
-    throw resp.status === 400 /* auth invalid */ ||
-    resp.status === 403 /* user not active */
-      ? ERR_INVALID_AUTH
-      : new Error("Unable to fetch tokens");
+    throw new HAWSError(
+      resp.status === 400 /* auth invalid */ ||
+      resp.status === 403 /* user not active */
+        ? ERR_INVALID_AUTH
+        : ERR_CANNOT_FETCH_TOKENS
+    );
   }
 
   const tokens: AuthData = await resp.json();
@@ -225,7 +232,7 @@ export async function getAuth(options: getAuthOptions = {}): Promise<Auth> {
   let hassUrl = options.hassUrl;
 
   if (hassUrl === undefined) {
-    throw ERR_HASS_HOST_REQUIRED;
+    throw new HAWSError(ERR_HASS_HOST_REQUIRED);
   }
 
   // Strip trailing slash.

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -320,7 +320,7 @@ export class Connection {
           const socket = await options.createSocket(options);
           this.setSocket(socket);
         } catch (err) {
-          if (err === ERR_INVALID_AUTH) {
+          if (err.code === ERR_INVALID_AUTH) {
             this.fireEvent("reconnect-error", err);
           } else {
             reconnect(tries + 1);

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,4 +1,21 @@
-export const ERR_CANNOT_CONNECT = 1;
-export const ERR_INVALID_AUTH = 2;
-export const ERR_CONNECTION_LOST = 3;
-export const ERR_HASS_HOST_REQUIRED = 4;
+export const ERR_CANNOT_CONNECT = "cannot_connect";
+export const ERR_INVALID_AUTH = "invalid_auth";
+export const ERR_CONNECTION_LOST = "connection_lost";
+export const ERR_HASS_HOST_REQUIRED = "hass_host_required";
+export const ERR_CANNOT_FETCH_TOKENS = "cannot_fetch_tokens";
+
+export type ErrorCode =
+  | "cannot_connect"
+  | "invalid_auth"
+  | "connection_lost"
+  | "hass_host_required"
+  | "cannot_fetch_tokens";
+
+export class HAWSError extends Error {
+  public code: ErrorCode;
+
+  constructor(code: ErrorCode) {
+    super();
+    this.code = code;
+  }
+}

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,5 +1,3 @@
-import { Error } from "./types";
-
 export function auth(accessToken: string) {
   return {
     type: "auth",
@@ -86,7 +84,7 @@ export function ping() {
   };
 }
 
-export function error(code: Error, message: string) {
+export function error(code: string, message: string) {
   return {
     type: "result",
     success: false,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,8 +4,6 @@ type Constructor<T> = {
   new (...args: unknown[]): T;
 };
 
-export type Error = 1 | 2 | 3 | 4;
-
 export type UnsubscribeFunc = () => void;
 
 export type ConnectionOptions = {


### PR DESCRIPTION
#### WIP: First let's decide how NodeJS error handling should be done. See https://github.com/home-assistant/home-assistant-js-websocket/pull/89#issuecomment-476396763

The error reporting system did not leave any room for metadata to be attached. This is needed to solve #89 elegantly.

- This PR changes all raised errors from this library from being just a number to being instances of the `Error` class. The previously available error code will now be set as the `code` property on the error instance.
- The values of the error constants have been updated from numbers to strings, to help with debugging (names of the constants did not change)
- Add a new error that can be raised from `getAuth`: `ERR_CANNOT_FETCH_TOKESN`. Raised when we try to fetch tokens but fail for any other reason than auth failure.

Once this PR is merged, #89 can be updated accordingly.

Updated example:

```ts
async function connect() {
  let auth;
  try {
    // Try to pick up authentication after user logs in
    auth = await getAuth();
  } catch (err) {
    if (err.code === ERR_HASS_HOST_REQUIRED) {
      const hassUrl = prompt(
        "What host to connect to?",
        "http://localhost:8123"
      );
      // Redirect user to log in on their instance
      auth = await getAuth({ hassUrl });
    } else {
      alert(`Unknown error: ${err.code}`);
      return;
    }
  }
  const connection = await createConnection({ auth });
  subscribeEntities(connection, ent => console.log(ent));
}
``` 

CC @keesschollaart81 @zachowj