### PR TITLE
Revert passing in WS constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ createConnection({ auth });
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | auth         | Auth object to use to create a connection.                                                                                                     |
 | createSocket | Override the createSocket method with your own. `(options) => Promise<WebSocket>`. Needs to return a connection that is already authenticated. |
-| WebSocket    | Constructor to use to initialize the WebSocket connection inside the built-in createSocket method.                                             |
 | setupRetry   | Number of times to retry initial connection when it fails. Set to -1 for infinite retries. Default is 0 (no retries)                           |
 
 Currently the following error codes can be raised by createConnection:
@@ -372,12 +371,19 @@ import {
 
 ## Using this in NodeJS
 
-NodeJS does not have a WebSocket client built-in, but there are some good ones on NPM. We recommend `ws`. You can pass the WebSocket constructor to use as part of the options.
+NodeJS does not have a WebSocket client built-in, but there are some good ones on NPM. We recommend `ws`. You will need to create your own version of `createSocket` and pass that to the constructor.
 
 ```js
 const WebSocket = require("ws");
 
 createConnection({
-  WebSocket
+  createSocket() {
+    WebSocket;
+    // Open connection
+    const ws = new WebSocket("ws://localhost:8123");
+    // Functions to handle authentication with Home Assistant
+    // Implement yourself :)
+    return ws;
+  }
 });
 ```

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -20,7 +20,6 @@ export function createSocket(options: ConnectionOptions): Promise<WebSocket> {
     throw ERR_HASS_HOST_REQUIRED;
   }
   const auth = options.auth;
-  const wsConstructor = options.WebSocket || WebSocket;
 
   // Start refreshing expired tokens even before the WS connection is open.
   // We know that we will need auth anyway.
@@ -51,8 +50,7 @@ export function createSocket(options: ConnectionOptions): Promise<WebSocket> {
       console.log("[Auth Phase] New connection", url);
     }
 
-    // @ts-ignore
-    const socket = new wsConstructor(url);
+    const socket = new WebSocket(url);
 
     // If invalid auth, we will not try to reconnect.
     let invalidAuth = false;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,9 +1,5 @@
 import { Auth } from "./auth";
 
-type Constructor<T> = {
-  new (...args: unknown[]): T;
-};
-
 export type Error = 1 | 2 | 3 | 4;
 
 export type UnsubscribeFunc = () => void;
@@ -12,7 +8,6 @@ export type ConnectionOptions = {
   setupRetry: number;
   auth?: Auth;
   createSocket: (options: ConnectionOptions) => Promise<WebSocket>;
-  WebSocket?: Constructor<WebSocket>;
 };
 
 export type MessageBase = {


### PR DESCRIPTION
This reverts #87.

It did not help with NodeJS integration, as was the driver of this change. After discussion in #89, decided NodeJS needs their own createSocket implementation.