### PR TITLE
Fix/typescript node websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,12 +377,10 @@ import {
 } from "home-assistant-js-websocket";
 
 (async () => {
-  let auth = new Auth({
-    access_token: "YOUR ACCESS OTKEN",
-    // Set expires to very far in the future
-    expires: new Date(new Date().getTime() + 1e11),
-    hassUrl: "http://localhost:8123"
-  });
+  const auth = Auth.createLongLived(
+    "http://localhost:8123",
+    "YOUR ACCESS TOKEN"
+  );
 
   const connection = await createConnection({ auth });
   subscribeEntities(connection, entities => console.log(entities));
@@ -391,7 +389,10 @@ import {
 
 ## Using this in NodeJS
 
-NodeJS does not have a WebSocket client built-in, but there are some good ones on NPM. We recommend `ws`. You will need to create your own version of `createSocket` and pass that to the constructor.
+NodeJS does not have a WebSocket client built-in, but there are some good ones on NPM. We recommend ws. You will need to create your own version of createSocket and pass that to the constructor.
+Look at https://github.com/keesschollaart81/vscode-home-assistant/blob/master/src/language-service/src/home-assistant/socket.ts as an example using ws.
+
+If using TypeScript, you will need to add `"skipLibCheck": true` to your tsconfig.json to avoid typing errors.
 
 ```js
 const WebSocket = require("ws");

--- a/README.md
+++ b/README.md
@@ -373,11 +373,12 @@ You will need to create your own auth object if you want to use this library wit
 import {
   Auth,
   createConnection,
-  subscribeEntities
+  subscribeEntities,
+  createLongLivedTokenAuth
 } from "home-assistant-js-websocket";
 
 (async () => {
-  const auth = Auth.createLongLived(
+  const auth = createLongLivedTokenAuth(
     "http://localhost:8123",
     "YOUR ACCESS TOKEN"
   );

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -169,17 +169,6 @@ export class Auth {
     this._saveTokens = saveTokens;
   }
 
-  static createLongLived(hassUrl: string, access_token: string) {
-    return new Auth({
-      hassUrl,
-      clientId: null,
-      expires: Date.now() + 1e11,
-      refresh_token: "",
-      access_token,
-      expires_in: 1e11
-    });
-  }
-
   get wsUrl() {
     // Convert from http:// -> ws://, https:// -> wss://
     return `ws${this.data.hassUrl.substr(4)}/api/websocket`;
@@ -190,7 +179,7 @@ export class Auth {
   }
 
   get expired() {
-    return !!this.data.refresh_token && Date.now() > this.data.expires;
+    return Date.now() > this.data.expires;
   }
 
   /**
@@ -230,6 +219,20 @@ export class Auth {
       this._saveTokens(null);
     }
   }
+}
+
+export function createLongLivedTokenAuth(
+  hassUrl: string,
+  access_token: string
+) {
+  return new Auth({
+    hassUrl,
+    clientId: null,
+    expires: Date.now() + 1e11,
+    refresh_token: "",
+    access_token,
+    expires_in: 1e11
+  });
 }
 
 export async function getAuth(options: getAuthOptions = {}): Promise<Auth> {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,6 +10,7 @@ export * from "./config.js";
 export * from "./services.js";
 export * from "./entities.js";
 export * from "./errors.js";
+export * from "./socket.js";
 export * from "./types.js";
 export * from "./commands.js";
 

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -11,9 +11,9 @@ import * as messages from "./messages.js";
 
 const DEBUG = false;
 
-const MSG_TYPE_AUTH_REQUIRED = "auth_required";
-const MSG_TYPE_AUTH_INVALID = "auth_invalid";
-const MSG_TYPE_AUTH_OK = "auth_ok";
+export const MSG_TYPE_AUTH_REQUIRED = "auth_required";
+export const MSG_TYPE_AUTH_INVALID = "auth_invalid";
+export const MSG_TYPE_AUTH_OK = "auth_ok";
 
 export interface HaWebSocket extends WebSocket {
   haVersion: string;

--- a/test/auth.spec.ts
+++ b/test/auth.spec.ts
@@ -7,7 +7,7 @@ describe("Auth", () => {
     const auth = new Auth({
       hassUrl: "",
       clientId: "",
-      refresh_token: "",
+      refresh_token: "fake token",
       access_token: "",
       expires_in: 3000,
       expires: Date.now() - 1000
@@ -18,7 +18,7 @@ describe("Auth", () => {
     const auth = new Auth({
       hassUrl: "",
       clientId: "",
-      refresh_token: "",
+      refresh_token: "fake token",
       access_token: "",
       expires_in: 3000,
       expires: Date.now() + 1000

--- a/test/auth.spec.ts
+++ b/test/auth.spec.ts
@@ -7,7 +7,7 @@ describe("Auth", () => {
     const auth = new Auth({
       hassUrl: "",
       clientId: "",
-      refresh_token: "fake token",
+      refresh_token: "",
       access_token: "",
       expires_in: 3000,
       expires: Date.now() - 1000
@@ -18,7 +18,7 @@ describe("Auth", () => {
     const auth = new Auth({
       hassUrl: "",
       clientId: "",
-      refresh_token: "fake token",
+      refresh_token: "",
       access_token: "",
       expires_in: 3000,
       expires: Date.now() + 1000


### PR DESCRIPTION
This simplifies and improves usability with TypeScript and nodejs.

1) Add a smaller `createWebSocket` function as a simpler way to create a socket on nodejs without having to 'write' (aka copy the libraries) authentication code
2) Better support for the `Auth` class for long-lived access tokens, with a friendlier way to instantiate the class without needing to cast or fill in a bunch of pointless properties.
