### PR TITLE
Modernize the build

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,5 +1,7 @@
 # https://github.com/mochajs/mocha/blob/master/example/config/.mocharc.yml
-require: ts-node/register
+require:
+  - ts-node/register
+  - reify
 timeout: 100
 watch-files:
   - "lib/*.ts"

--- a/example.html
+++ b/example.html
@@ -13,7 +13,7 @@
         createConnection,
         subscribeEntities,
         ERR_HASS_HOST_REQUIRED
-      } from "./dist/haws.es.js";
+      } from "./dist/index.js";
 
       (async () => {
         let auth;
@@ -36,11 +36,18 @@
         subscribeEntities(connection, entities =>
           renderEntities(connection, entities)
         );
+        // Clear url if we have been able to establish a connection
+        if (location.search.includes("auth_callback=1")) {
+          history.replaceState(null, "", location.pathname);
+        }
 
         // To play from the console
         window.auth = auth;
         window.connection = connection;
-        getUser(connection).then(user => console.log("Logged in as", user));
+        getUser(connection).then(user => {
+          console.log("Logged in as", user);
+          window.user = user;
+        });
       })();
 
       function renderEntities(connection, entities) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,9 +1,9 @@
-import { parseQuery } from "./util";
+import { parseQuery } from "./util.js";
 import {
   ERR_HASS_HOST_REQUIRED,
   ERR_INVALID_AUTH,
   ERR_INVALID_HTTPS_TO_HTTP
-} from "./errors";
+} from "./errors.js";
 
 export type AuthData = {
   hassUrl: string;

--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -1,6 +1,6 @@
-import { Store, createStore } from "./store";
-import { Connection } from "./connection";
-import { UnsubscribeFunc } from "./types";
+import { Store, createStore } from "./store.js";
+import { Connection } from "./connection.js";
+import { UnsubscribeFunc } from "./types.js";
 
 export type Collection<State> = {
   state: State;

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -1,6 +1,6 @@
-import { Connection } from "./connection";
-import * as messages from "./messages";
-import { HassEntity, HassServices, HassConfig, HassUser } from "./types";
+import { Connection } from "./connection.js";
+import * as messages from "./messages.js";
+import { HassEntity, HassServices, HassConfig, HassUser } from "./types.js";
 
 export const getStates = (connection: Connection) =>
   connection.sendMessagePromise<HassEntity[]>(messages.states());

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,8 +1,8 @@
-import { getCollection } from "./collection";
-import { HassConfig, UnsubscribeFunc } from "./types";
-import { Connection } from "./connection";
-import { Store } from "./store";
-import { getConfig } from "./commands";
+import { getCollection } from "./collection.js";
+import { HassConfig, UnsubscribeFunc } from "./types.js";
+import { Connection } from "./connection.js";
+import { Store } from "./store.js";
+import { getConfig } from "./commands.js";
 
 type ComponentLoadedEvent = {
   data: {

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -2,10 +2,10 @@
  * Connection that wraps a socket and provides an interface to interact with
  * the Home Assistant websocket API.
  */
-import * as messages from "./messages";
-import { ERR_INVALID_AUTH, ERR_CONNECTION_LOST } from "./errors";
-import { ConnectionOptions, HassEvent, MessageBase } from "./types";
-import { HaWebSocket } from "./socket";
+import * as messages from "./messages.js";
+import { ERR_INVALID_AUTH, ERR_CONNECTION_LOST } from "./errors.js";
+import { ConnectionOptions, HassEvent, MessageBase } from "./types.js";
+import { HaWebSocket } from "./socket.js";
 
 const DEBUG = false;
 

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -1,8 +1,8 @@
-import { getCollection } from "./collection";
-import { HassEntities, StateChangedEvent, UnsubscribeFunc } from "./types";
-import { Connection } from "./connection";
-import { Store } from "./store";
-import { getStates } from "./commands";
+import { getCollection } from "./collection.js";
+import { HassEntities, StateChangedEvent, UnsubscribeFunc } from "./types.js";
+import { Connection } from "./connection.js";
+import { Store } from "./store.js";
+import { getStates } from "./commands.js";
 
 function processEvent(store: Store<HassEntities>, event: StateChangedEvent) {
   const state = store.state;
@@ -12,7 +12,7 @@ function processEvent(store: Store<HassEntities>, event: StateChangedEvent) {
   if (new_state) {
     store.setState({ [new_state.entity_id]: new_state });
   } else {
-    const newEntities = Object.assign({}, state);
+    const newEntities = { ...state };
     delete newEntities[entity_id];
     store.setState(newEntities, true);
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,28 +1,25 @@
-import { ConnectionOptions } from "./types";
-import { createSocket } from "./socket";
-import { Connection } from "./connection";
+// JS extensions in imports allow tsc output to be consumed by browsers.
+import { ConnectionOptions } from "./types.js";
+import { createSocket } from "./socket.js";
+import { Connection } from "./connection.js";
 
-export * from "./auth";
-export * from "./collection";
-export * from "./connection";
-export * from "./config";
-export * from "./services";
-export * from "./entities";
-export * from "./errors";
-export * from "./types";
-export * from "./commands";
-
-const defaultConnectionOptions: ConnectionOptions = {
-  setupRetry: 0,
-  createSocket
-};
+export * from "./auth.js";
+export * from "./collection.js";
+export * from "./connection.js";
+export * from "./config.js";
+export * from "./services.js";
+export * from "./entities.js";
+export * from "./errors.js";
+export * from "./types.js";
+export * from "./commands.js";
 
 export async function createConnection(options?: Partial<ConnectionOptions>) {
-  const connOptions: ConnectionOptions = Object.assign(
-    {},
-    defaultConnectionOptions,
-    options
-  );
+  const connOptions: ConnectionOptions = {
+    setupRetry: 0,
+    createSocket,
+    ...options
+  };
+
   const socket = await connOptions.createSocket(connOptions);
   const conn = new Connection(socket, connOptions);
   return conn;

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,4 +1,4 @@
-import { Error } from "./types";
+import { Error } from "./types.js";
 
 export function auth(accessToken: string) {
   return {

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -1,8 +1,8 @@
-import { getCollection } from "./collection";
-import { HassServices, HassDomainServices, UnsubscribeFunc } from "./types";
-import { Connection } from "./connection";
-import { Store } from "./store";
-import { getServices } from "./commands";
+import { getCollection } from "./collection.js";
+import { HassServices, HassDomainServices, UnsubscribeFunc } from "./types.js";
+import { Connection } from "./connection.js";
+import { Store } from "./store.js";
+import { getServices } from "./commands.js";
 
 type ServiceRegisteredEvent = {
   data: {

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -5,9 +5,9 @@ import {
   ERR_INVALID_AUTH,
   ERR_CANNOT_CONNECT,
   ERR_HASS_HOST_REQUIRED
-} from "./errors";
-import { ConnectionOptions, Error } from "./types";
-import * as messages from "./messages";
+} from "./errors.js";
+import { ConnectionOptions, Error } from "./types.js";
+import * as messages from "./messages.js";
 
 const DEBUG = false;
 

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,4 +1,4 @@
-import { UnsubscribeFunc } from "./types";
+import { UnsubscribeFunc } from "./types.js";
 
 // (c) Jason Miller
 // Unistore - MIT license
@@ -34,7 +34,7 @@ export const createStore = <State>(state?: State): Store<State> => {
   }
 
   function setState(update: Partial<State>, overwrite: boolean): void {
-    state = overwrite ? (update as State) : Object.assign({}, state, update);
+    state = overwrite ? (update as State) : { ...state!, ...update };
     let currentListeners = listeners;
     for (let i = 0; i < currentListeners.length; i++) {
       currentListeners[i](state);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
-import { Auth } from "./auth";
-import { HaWebSocket } from "./socket";
+import { Auth } from "./auth.js";
+import { HaWebSocket } from "./socket.js";
 
 export type Error = 1 | 2 | 3 | 4;
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "home-assistant-js-websocket",
   "type": "module",
   "sideEffects": false,
-  "version": "4.6.0",
+  "version": "5.0.0",
   "description": "Home Assistant websocket client",
   "source": "lib/index.ts",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,32 +1,39 @@
 {
   "name": "home-assistant-js-websocket",
-  "amdName": "HAWS",
+  "type": "module",
   "sideEffects": false,
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Home Assistant websocket client",
   "source": "lib/index.ts",
   "types": "dist/index.d.ts",
   "main": "dist/haws.umd.js",
-  "module": "dist/haws.es.js",
+  "module": "dist/index.js",
+  "exports": {
+    "import": "dist/index.js",
+    "default": "dist/haws.umd.js"
+  },
   "repository": {
     "url": "https://github.com/home-assistant/home-assistant-js-websocket.git",
     "type": "git"
   },
   "scripts": {
-    "watch": "microbundle watch",
-    "build": "microbundle",
-    "test": "mocha",
-    "prepublishOnly": "rm -rf dist && microbundle && npm test"
+    "watch": "tsc --watch",
+    "build": "tsc && rollup dist/index.js --format umd --name HAWS --file dist/haws.umd.js",
+    "test": "tsc && mocha",
+    "prepublishOnly": "rm -rf dist && yarn build && npm test"
   },
   "author": "Paulus Schoutsen <paulus@paulusschoutsen.nl>",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/assert": "^1.4.6",
     "@types/mocha": "^7.0.2",
+    "assert": "^2.0.0",
     "husky": "^4.2.3",
     "lint-staged": "^10.0.8",
-    "microbundle": "^0.11.0",
     "mocha": "^7.1.0",
     "prettier": "^1.19.1",
+    "reify": "^0.20.12",
+    "rollup": "^2.0.0",
     "ts-node": "^8.6.2",
     "typescript": "^3.8.3"
   },

--- a/test/auth.spec.ts
+++ b/test/auth.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 
-import { Auth } from "../lib/auth";
+import { Auth } from "../dist/auth";
 
 describe("Auth", () => {
   it("should indicate correctly when token expired", () => {

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 
-import { subscribeConfig } from "../lib/config";
+import { subscribeConfig } from "../dist/config";
 import { MockConnection, AwaitableEvent } from "./util";
 
 const MOCK_CONFIG = {

--- a/test/entities.spec.ts
+++ b/test/entities.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 
-import { subscribeEntities } from "../lib/entities";
+import { subscribeEntities } from "../dist/entities";
 import { MockConnection, AwaitableEvent } from "./util";
 
 const MOCK_LIGHT = {

--- a/test/services.spec.ts
+++ b/test/services.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 
-import { subscribeServices } from "../lib/services";
+import { subscribeServices } from "../dist/services";
 import { MockConnection, AwaitableEvent } from "./util";
 
 const MOCK_SERVICES = {

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,5 +1,5 @@
-import { Connection } from "../lib/connection";
-import { HaWebSocket } from "../lib/socket";
+import { Connection } from "../dist/connection";
+import { HaWebSocket } from "../dist/socket";
 
 class MockWebSocket {
   addEventListener(eventType: string, callback: () => {}) {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "lib": ["es2015", "dom"],
     "target": "es2017",
     "outDir": "dist",
+    "declaration": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Migrate from `microbundle` to `tsc` to create the module version and use rollup to create the UMD version. Our module build will now not be bundled up but just be ES2017 code using native async/await. It's up to consumers of this package to decide on how to deal with this.

Tests are also run against the transpiled build so we're testing against prod builds.

To make our module build browser compatible, we're now requiring all import specifiers to include `.js`.

Dropped `Object.assign` too in favor of `...`
