### PR TITLE
Add new external & internal URL core configs to HassConfig

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -58,6 +58,8 @@ export type HassConfig = {
   version: string;
   config_source: string;
   safe_mode: boolean;
+  external_url: string | null;
+  internal_url: string | null;
 };
 
 export type HassEntityBase = {


### PR DESCRIPTION
Adds new core configuration options `external_url` and `internal_url` to HassConfig definition.


- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13307
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/5755
- Link to core pull request: https://github.com/home-assistant/core/pull/35224
