### PR TITLE
Don't send unsubscribe msg when not connected

### DIFF
--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -26,14 +26,13 @@ export const getCollection = <State>(
   let store = createStore<State>();
 
   const refresh = () =>
-    fetchCollection(conn).then(state => store.setState(state, true));
+    fetchCollection(conn).then((state) => store.setState(state, true));
 
   const refreshSwallow = () =>
     refresh().catch((err: unknown) => {
       // Swallow errors if socket is connecting, closing or closed.
       // We will automatically call refresh again when we re-establish the connection.
-      // Using conn.socket.OPEN instead of WebSocket for better node support
-      if (conn.socket.readyState == conn.socket.OPEN) {
+      if (conn.connected) {
         throw err;
       }
     });
@@ -74,13 +73,13 @@ export const getCollection = <State>(
         if (!active) {
           // Unsubscribe from changes
           if (unsubProm)
-            unsubProm.then(unsub => {
+            unsubProm.then((unsub) => {
               unsub();
             });
           conn.removeEventListener("ready", refresh);
         }
       };
-    }
+    },
   };
 
   return conn[key];

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -107,6 +107,11 @@ export class Connection {
     return this.socket.haVersion;
   }
 
+  get connected() {
+    // Using conn.socket.OPEN instead of WebSocket for better node support
+    return this.socket.readyState == this.socket.OPEN;
+  }
+
   setSocket(socket: HaWebSocket) {
     const oldSocket = this.socket;
     this.socket = socket;
@@ -249,6 +254,10 @@ export class Connection {
         callback,
         subscribe: () => this.subscribeMessage(callback, subscribeMessage),
         unsubscribe: async () => {
+          // No need to unsubscribe if we're disconnected
+          if (!this.connected) {
+            return;
+          }
           await this.sendMessagePromise(messages.unsubscribeEvents(commandId));
           this.commands.delete(commandId);
         },


### PR DESCRIPTION
When we're unsubscribing from a subscription, only send the message if we're actually connected.