### PR TITLE
Fix memory leak in unsubscribe while disconnected

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -297,10 +297,11 @@ export class Connection {
         subscribe: () => this.subscribeMessage(callback, subscribeMessage),
         unsubscribe: async () => {
           // No need to unsubscribe if we're disconnected
-          if (!this.connected) {
-            return;
+          if (this.connected) {
+            await this.sendMessagePromise(
+              messages.unsubscribeEvents(commandId)
+            );
           }
-          await this.sendMessagePromise(messages.unsubscribeEvents(commandId));
           this.commands.delete(commandId);
         },
       };


### PR DESCRIPTION
We should still pop the command from the ongoing commands when we're unsubscribing while disconnected. This was causing a memory leak.