### PR TITLE
Use conditional exports for node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "Home Assistant websocket client",
   "source": "lib/index.ts",
   "types": "dist/index.d.ts",
-  "main": "dist/haws.umd.js",
+  "main": "dist/haws.umd.cjs",
   "module": "dist/index.js",
   "repository": {
     "url": "https://github.com/home-assistant/home-assistant-js-websocket.git",
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "watch": "tsc --watch",
-    "build": "tsc && rollup dist/index.js --format umd --name HAWS --file dist/haws.umd.js",
+    "build": "tsc && rollup dist/index.js --format umd --name HAWS --file dist/haws.umd.cjs",
     "test": "tsc && mocha",
     "prepublishOnly": "rm -rf dist && yarn build && npm test"
   },

--- a/package.json
+++ b/package.json
@@ -6,15 +6,21 @@
   "description": "Home Assistant websocket client",
   "source": "lib/index.ts",
   "types": "dist/index.d.ts",
-  "main": "dist/haws.umd.cjs",
+  "main": "dist/haws.umd.js",
   "module": "dist/index.js",
+  "exports": {
+    "node": {
+      "import": "./dist/index.js",
+      "require": "./dist/haws.cjs"
+    }
+  },
   "repository": {
     "url": "https://github.com/home-assistant/home-assistant-js-websocket.git",
     "type": "git"
   },
   "scripts": {
     "watch": "tsc --watch",
-    "build": "tsc && rollup dist/index.js --format umd --name HAWS --file dist/haws.umd.cjs",
+    "build": "tsc && rollup -c",
     "test": "tsc && mocha",
     "prepublishOnly": "rm -rf dist && yarn build && npm test"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,14 @@
+export default {
+  input: "dist/index.js",
+  output: [
+    {
+      file: "dist/haws.cjs",
+      format: "cjs",
+    },
+    {
+      file: "dist/haws.umd.js",
+      format: "umd",
+      name: "HAWS",
+    },
+  ],
+};


### PR DESCRIPTION
Since the modernization of the build, https://github.com/home-assistant/home-assistant-js-websocket/pull/112, you have been unable to use this package with Node.js 12,13, and 14 using CommonJS require because of the following error.

```
[warn] [node-red-contrib-home-assistant-websocket/server] Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: E:\projects\node-red-contrib-home-assistant-websocket\node_modules\home-assistant-js-websocket\dist\haws.umd.js
require() of ES modules is not supported.
require() of E:\projects\node-red-contrib-home-assistant-websocket\node_modules\home-assistant-js-websocket\dist\haws.umd.js from E:\projects\node-red-contrib-home-assistant-websocket\lib\ha-websocket.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename haws.umd.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from E:\projects\node-red-contrib-home-assistant-websocket\node_modules\home-assistant-js-websocket\package.json.
```

This pull request changes the exported file extension to `.cjs` for the main module. This fixes the error for Node.js 12.18.3, 13.14.0, and 14.6.0 and still functions correctly in version 10.22.0.

I am unaware if this change affects any other environments that may use this package.