### PR TITLE
Add optional parameter to subscribeMessage to stop resubscription on reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,13 +363,17 @@ Listen for events on the connection. [See docs.](#automatic-reconnecting)
 
 Send a message to the server. Returns a promise that resolves or rejects based on the result of the server. Special case rejection is `ERR_CONNECTION_LOST` if the connection is lost while the command is in progress.
 
-##### `conn.subscribeMessage(callback, subscribeMessage[, resubscribe = true])`
+##### `conn.subscribeMessage(callback, subscribeMessage[, options])`
 
 Call an endpoint in Home Assistant that creates a subscription. Calls `callback` for each item that gets received.
 
 Returns a promise that will resolve to a function that will cancel the subscription once called.
 
-Subscription will be automatically re-established after a reconnect unless `resubscribe` is false.
+Subscription will be automatically re-established after a reconnect unless `options.resubscribe` is false.
+
+| Option      | Description                                     |
+| ----------- | ----------------------------------------------- |
+| resubscribe | Re-established a subscription after a reconnect |
 
 ## Auth API Reference
 

--- a/README.md
+++ b/README.md
@@ -363,13 +363,13 @@ Listen for events on the connection. [See docs.](#automatic-reconnecting)
 
 Send a message to the server. Returns a promise that resolves or rejects based on the result of the server. Special case rejection is `ERR_CONNECTION_LOST` if the connection is lost while the command is in progress.
 
-##### `conn.subscribeMessage(callback, subscribeMessage)`
+##### `conn.subscribeMessage(callback, subscribeMessage[, resubscribe = true])`
 
 Call an endpoint in Home Assistant that creates a subscription. Calls `callback` for each item that gets received.
 
 Returns a promise that will resolve to a function that will cancel the subscription once called.
 
-Subscription will be automatically re-established after a reconnect.
+Subscription will be automatically re-established after a reconnect unless `resubscribe` is false.
 
 ## Auth API Reference
 

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -276,7 +276,7 @@ export class Connection {
   async subscribeMessage<Result>(
     callback: (result: Result) => void,
     subscribeMessage: MessageBase,
-    resubscribe: boolean = true
+    options?: { resubscribe?: boolean }
   ): Promise<SubscriptionUnsubscribe> {
     if (this._queuedMessages) {
       await new Promise((resolve, reject) => {
@@ -296,7 +296,7 @@ export class Connection {
         resolve,
         reject,
         callback,
-        subscribe: resubscribe
+        subscribe: options?.resubscribe !== false
           ? () => this.subscribeMessage(callback, subscribeMessage)
           : undefined,
         unsubscribe: async () => {

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -270,7 +270,7 @@ export class Connection {
    *
    * @param message the message to start the subscription
    * @param callback the callback to be called when a new item arrives
-   * @param [resubscribe=true] re-established a subscription after a reconnect
+   * @param [options.resubscribe] re-established a subscription after a reconnect
    * @returns promise that resolves to an unsubscribe function
    */
   async subscribeMessage<Result>(
@@ -296,9 +296,10 @@ export class Connection {
         resolve,
         reject,
         callback,
-        subscribe: options?.resubscribe !== false
-          ? () => this.subscribeMessage(callback, subscribeMessage)
-          : undefined,
+        subscribe:
+          options?.resubscribe !== false
+            ? () => this.subscribeMessage(callback, subscribeMessage)
+            : undefined,
         unsubscribe: async () => {
           // No need to unsubscribe if we're disconnected
           if (this.connected) {

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -63,7 +63,7 @@ interface SubscribeEventCommmandInFlight<T> {
   resolve: (result?: any) => void;
   reject: (err: any) => void;
   callback: (ev: T) => void;
-  subscribe: () => Promise<SubscriptionUnsubscribe>;
+  subscribe: (() => Promise<SubscriptionUnsubscribe>) | undefined;
   unsubscribe: SubscriptionUnsubscribe;
 }
 
@@ -133,7 +133,7 @@ export class Connection {
       this.commands = new Map();
 
       oldCommands.forEach((info) => {
-        if ("subscribe" in info) {
+        if ("subscribe" in info && info.subscribe) {
           info.subscribe().then((unsub) => {
             info.unsubscribe = unsub;
             // We need to resolve this in case it wasn't resolved yet.
@@ -270,11 +270,13 @@ export class Connection {
    *
    * @param message the message to start the subscription
    * @param callback the callback to be called when a new item arrives
+   * @param [resubscribe=true] re-established a subscription after a reconnect
    * @returns promise that resolves to an unsubscribe function
    */
   async subscribeMessage<Result>(
     callback: (result: Result) => void,
-    subscribeMessage: MessageBase
+    subscribeMessage: MessageBase,
+    resubscribe: boolean = true
   ): Promise<SubscriptionUnsubscribe> {
     if (this._queuedMessages) {
       await new Promise((resolve, reject) => {
@@ -294,7 +296,9 @@ export class Connection {
         resolve,
         reject,
         callback,
-        subscribe: () => this.subscribeMessage(callback, subscribeMessage),
+        subscribe: resubscribe
+          ? () => this.subscribeMessage(callback, subscribeMessage)
+          : undefined,
         unsubscribe: async () => {
           // No need to unsubscribe if we're disconnected
           if (this.connected) {


### PR DESCRIPTION
Add an optional parameter to the `subscribeMessage` to be able to set whether or not to re-establish the subscription after a reconnect.

Fixes: #130 