### PR TITLE
Add dist to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
   "main": "dist/haws.umd.js",
   "module": "dist/index.js",
   "exports": {
-    "node": {
+    ".": {
       "import": "./dist/index.js",
-      "require": "./dist/haws.cjs"
-    }
+      "require": "./dist/haws.cjs",
+      "default": "./dist/haws.umd.js"
+    },
+    "./dist/": "./dist/"
   },
   "repository": {
     "url": "https://github.com/home-assistant/home-assistant-js-websocket.git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
       "default": "./dist/haws.umd.js"
     },
     "./haws.cjs": "./dist/haws.cjs",
-    "./haws.umd.js": "./dist/haws.umd.js"
+    "./haws.umd.js": "./dist/haws.umd.js",
+    "./dist/": "./dist/"
   },
   "repository": {
     "url": "https://github.com/home-assistant/home-assistant-js-websocket.git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
       "require": "./dist/haws.cjs",
       "default": "./dist/haws.umd.js"
     },
-    "./dist/": "./dist/"
+    "./haws.cjs": "./dist/haws.cjs",
+    "./haws.umd.js": "./dist/haws.umd.js"
   },
   "repository": {
     "url": "https://github.com/home-assistant/home-assistant-js-websocket.git",


### PR DESCRIPTION
Allows the use of `require("home-assistant-js-websocket/dist/haws.cjs")` to support both newer and older versions of Node.js