### PR TITLE
Use enum for Domain and DeviceClass

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -58,6 +58,111 @@ export type HassConfig = {
   internal_url: string | null;
 };
 
+export enum Domain {
+  MEDIA_PLAYER = "media_player",
+  ALARM_CONTROL_PANEL = "alarm_control_panel",
+  BINARY_SENSOR = "binary_sensor",
+  COVER = "cover",
+  LOCK = "lock",
+  HUMIDIFIER = "humidifier",
+  ZWAVE = "zwave",
+  ALERT = "alert",
+  ALEXA = "alexa",
+  AIR_QUALITY = "air_quality",
+  AUTOMATION = "automation",
+  CALENDAR = "calendar",
+  CAMERA = "camera",
+  CLIMATE = "climate",
+  CONFIGURATOR = "configurator",
+  CONVERSATION = "conversation",
+  COUNTER = "counter",
+  DEVICE_TRACKER = "device_tracker",
+  FAN = "fan",
+  GOOGLE_ASSISTANT = "google_assistant",
+  GROUP = "group",
+  HOMEASSISTANT = "homeassistant",
+  HOMEKIT = "homekit",
+  IMAGE_PROCESSING = "image_processing",
+  INPUT_BOOLEAN = "input_boolean",
+  INPUT_DATETIME = "input_datetime",
+  INPUT_NUMBER = "input_number",
+  INPUT_SELECT = "input_select",
+  INPUT_TEXT = "input_text",
+  LIGHT = "light",
+  MAILBOX = "mailbox",
+  NOTIFY = "notify",
+  NUMBER = "number",
+  PERSISTENT_NOTIFICATION = "persistent_notification",
+  PERSON = "person",
+  PLANT = "plant",
+  PROXIMITY = "proximity",
+  REMOTE = "remote",
+  SCENE = "scene",
+  SCRIPT = "script",
+  SENSOR = "sensor",
+  SIMPLE_ALARM = "simple_alarm",
+  SUN = "sun",
+  SWITCH = "switch",
+  TIMER = "timer",
+  UPDATER = "updater",
+  VACUUM = "vacuum",
+  WATER_HEATER = "water_heater",
+  WEATHER = "weather",
+  ZONE = "zone",
+  GEO_LOCATION = "geo_location",
+  TTS = "tts",
+}
+
+export enum DeviceClass {
+  CURRENT = "current",
+  CARBON_DIOXIDE = "carbon_dioxide",
+  TEMPERATURE = "temperature",
+  PRESSURE = "pressure",
+  ILLUMINANCE = "illuminance",
+  HUMIDITY = "humidity",
+  CARBON_MONOXIDE = "carbon_monoxide",
+  ENERGY = "energy",
+  BATTERY = "battery",
+  CONNECTIVITY = "connectivity",
+  GARAGE_DOOR = "garage_door",
+  OPENING = "opening",
+  WINDOW = "window",
+  LOCK = "lock",
+  PLUG = "plug",
+  PRESENCE = "presence",
+  SAFETY = "safety",
+  COLD = "cold",
+  GAS = "gas",
+  HEAT = "heat",
+  COLIGHTLD = "colightld",
+  MOISTURE = "moisture",
+  MOTION = "motion",
+  OCCUPANCY = "occupancy",
+  POWER = "power",
+  POWER_FACTOR = "power_factor",
+  PROBLEM = "problem",
+  SIGNAL_STRENGTH = "signal_strength",
+  SMOKE = "smoke",
+  SOUND = "sound",
+  VIBRATION = "vibration",
+  TIMESTAMP = "timestamp",
+  VOLTAGE = "voltage",
+  BATTERY_CHARGING = "battery_charging",
+  MOON_PHASE = "moon_phase",
+  GATE = "gate",
+  AWNING = "awning",
+  DOOR = "door",
+  SHADE = "shade",
+  BLIND = "blind",
+  CURTAIN = "curtain",
+  SHUTTER = "shutter",
+  LIGHT = "light",
+  MOVING = "moving",
+  DAMPER = "damper",
+  ALPR = "alpr",
+  FACE = "face",
+}
+
 export type HassEntityBase = {
   entity_id: string;
   state: string;
@@ -75,7 +180,7 @@ export type HassEntityAttributeBase = {
   supported_features?: number;
   hidden?: boolean;
   assumed_state?: boolean;
-  device_class?: string;
+  device_class?: DeviceClass;
 };
 
 export type HassEntity = HassEntityBase & {
@@ -102,9 +207,7 @@ export type HassDomainServices = {
   [service_name: string]: HassService;
 };
 
-export type HassServices = {
-  [domain: string]: HassDomainServices;
-};
+export type HassServices = Record<Domain, HassDomainServices>;
 
 export type HassUser = {
   id: string;


### PR DESCRIPTION
This updates Domain and DeviceClass to be an enum.

TODO:
- [ ] Check whether arbitrary domains/device classes are permitted/whether these can actually be enumerated?
- [ ] Open PR against frontend repo (I have this prepped with tests passing). Pending answer to the above.

The benefits of this is that we can guarantee we cater for all usecases in things like icons if we add a new class. We also avoid accidental typos/spelling (like "garage" vs "garage_door").