### PR TITLE
Add currency core configuration

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -56,6 +56,7 @@ export type HassConfig = {
   state: "NOT_RUNNING" | "STARTING" | "RUNNING" | "STOPPING" | "FINAL_WRITE";
   external_url: string | null;
   internal_url: string | null;
+  currency: string | null;
 };
 
 export type HassEntityBase = {


### PR DESCRIPTION
This PR adds the core `currency` option to the WebSocket lib.

Core PR: <https://github.com/home-assistant/core/pull/53541>