### PR TITLE
Add state_class to HassEntityAttributeBase

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -77,6 +77,7 @@ export type HassEntityAttributeBase = {
   hidden?: boolean;
   assumed_state?: boolean;
   device_class?: string;
+  state_class?: string;
 };
 
 export type HassEntity = HassEntityBase & {


### PR DESCRIPTION
This adds the `state_class` attribute to `HasEntityAttributeBase`. I'm working on a PR for the frontend that checks for `state_class` to apply number formatting (see discussion at https://github.com/home-assistant/home-assistant.io/pull/19933), and typescript throws an error when I check for this attribute using the `HasEntityAttributeBase` type.

I can extend `HassEntityAttributeBase` the way the `HassEntity` type does to avoid the error in my PR, but this seems like a more appropriate and future-proof solution unless there is a specific reason to _not_ include `state_class` here?