### PR TITLE
Update the unit_system type with recently added fields

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,6 +43,9 @@ export type HassConfig = {
     mass: string;
     volume: string;
     temperature: string;
+    pressure: string;
+    wind_speed: string;
+    accumulated_precipitation: string;
   };
   location_name: string;
   time_zone: string;


### PR DESCRIPTION
Adds pressure, [wind speed](https://github.com/home-assistant/core/pull/58437) and [accumulated precipitation](https://github.com/home-assistant/core/pull/59657) units to the `unit_system` type.