### PR TITLE
Store old subscriptions to actually restore

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -407,6 +407,7 @@ export class Connection {
 
     // reset to original state except haVersion
     this.commandId = 1;
+    this.oldSubscriptions = this.commands;
     this.commands = new Map();
     this.socket = undefined;
 


### PR DESCRIPTION
In #226 I introduced `this.oldSubscriptions` to be restored when a new socket was set. However this variable was never set. This fixes it.