### PR TITLE
Add support for subscribe entities

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ yarn-error.log
 LICENSE.md
 CLA.md
 CODE_OF_CONDUCT.md
+.reify-cache

--- a/example.html
+++ b/example.html
@@ -17,16 +17,31 @@
 
       (async () => {
         let auth;
+        const storeAuth = true;
+        const authOptions = storeAuth
+          ? {
+              async loadTokens() {
+                try {
+                  return JSON.parse(localStorage.hassTokens);
+                } catch (err) {
+                  return undefined;
+                }
+              },
+              saveTokens: (tokens) => {
+                localStorage.hassTokens = JSON.stringify(tokens);
+              },
+            }
+          : {};
         try {
-          auth = await getAuth();
+          auth = await getAuth(authOptions);
         } catch (err) {
           if (err === ERR_HASS_HOST_REQUIRED) {
-            const hassUrl = prompt(
+            authOptions.hassUrl = prompt(
               "What host to connect to?",
               "http://localhost:8123"
             );
-            if (!hassUrl) return;
-            auth = await getAuth({ hassUrl });
+            if (!authOptions.hassUrl) return;
+            auth = await getAuth(authOptions);
           } else {
             alert(`Unknown error: ${err}`);
             return;
@@ -51,6 +66,7 @@
       })();
 
       function renderEntities(connection, entities) {
+        window.entities = entities;
         const root = document.querySelector("tbody");
         while (root.lastChild) root.removeChild(root.lastChild);
 

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -295,7 +295,7 @@ export class Connection {
    *
    * @param message the message to start the subscription
    * @param callback the callback to be called when a new item arrives
-   * @param [options.resubscribe] re-established a subscription after a reconnect
+   * @param [options.resubscribe] re-established a subscription after a reconnect. Defaults to true.
    * @returns promise that resolves to an unsubscribe function
    */
   async subscribeMessage<Result>(

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -24,22 +24,27 @@ interface EntityState {
 }
 
 interface EntityDiff {
+  /** additions */
   "+"?: Partial<EntityState>;
+  /** subtractions */
   "-"?: Pick<EntityState, "a">;
 }
 
 interface StatesUpdates {
-  add?: Record<string, EntityState>;
-  removed?: string[];
-  changed: Record<string, EntityDiff>;
+  /** add */
+  a?: Record<string, EntityState>;
+  /** remove */
+  r?: string[]; // remove
+  /** change */
+  c: Record<string, EntityDiff>;
 }
 
 function processEvent(store: Store<HassEntities>, updates: StatesUpdates) {
   const state = { ...store.state };
 
-  if (updates.add) {
-    for (const entityId in updates.add) {
-      const newState = updates.add[entityId];
+  if (updates.a) {
+    for (const entityId in updates.a) {
+      const newState = updates.a[entityId];
       let last_changed = new Date(newState.lc * 1000).toISOString();
       state[entityId] = {
         entity_id: entityId,
@@ -52,14 +57,14 @@ function processEvent(store: Store<HassEntities>, updates: StatesUpdates) {
     }
   }
 
-  if (updates.removed) {
-    for (const entityId of updates.removed) {
+  if (updates.r) {
+    for (const entityId of updates.r) {
       delete state[entityId];
     }
   }
 
-  if (updates.changed) {
-    for (const entityId in updates.changed) {
+  if (updates.c) {
+    for (const entityId in updates.c) {
       let entityState = state[entityId];
 
       if (!entityState) {
@@ -69,7 +74,7 @@ function processEvent(store: Store<HassEntities>, updates: StatesUpdates) {
 
       entityState = { ...entityState };
 
-      const { "+": toAdd, "-": toRemove } = updates.changed[entityId];
+      const { "+": toAdd, "-": toRemove } = updates.c[entityId];
 
       if (toAdd) {
         if (toAdd.s) {

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -141,7 +141,7 @@ async function legacyFetchEntities(conn: Connection): Promise<HassEntities> {
 
 const legacySubscribeUpdates = (conn: Connection, store: Store<HassEntities>) =>
   conn.subscribeEvents<StateChangedEvent>(
-    (ev) => processEvent(store, ev as StateChangedEvent),
+    (ev) => legacyProcessEvent(store, ev as StateChangedEvent),
     "state_changed"
   );
 

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -1,10 +1,121 @@
 import { getCollection } from "./collection.js";
-import { HassEntities, StateChangedEvent, UnsubscribeFunc } from "./types.js";
+import {
+  Context,
+  HassEntities,
+  StateChangedEvent,
+  UnsubscribeFunc,
+} from "./types.js";
 import { Connection } from "./connection.js";
 import { Store } from "./store.js";
 import { getStates } from "./commands.js";
+import { atLeastHaVersion } from "./util.js";
 
-function processEvent(store: Store<HassEntities>, event: StateChangedEvent) {
+interface EntityState {
+  /** state */
+  s: string;
+  /** attributes */
+  a: { [key: string]: any };
+  /** context */
+  c: Context;
+  /** last_changed; if set, also applies to lu */
+  lc: string;
+  /** last_updated */
+  lu: string;
+}
+
+interface EntityDiff {
+  "+"?: Partial<EntityState>;
+  "-"?: Pick<EntityState, "a">;
+}
+
+interface StatesUpdates {
+  add?: Record<string, EntityState>;
+  removed?: string[];
+  changed: Record<string, EntityDiff>;
+}
+
+function processEvent(store: Store<HassEntities>, updates: StatesUpdates) {
+  const state = { ...store.state };
+
+  if (updates.add) {
+    for (const entityId in updates.add) {
+      const newState = updates.add[entityId];
+      state[entityId] = {
+        entity_id: entityId,
+        state: newState.s,
+        attributes: newState.a,
+        context: newState.c,
+        last_changed: newState.lc,
+        last_updated: newState.lu,
+      };
+    }
+  }
+
+  if (updates.removed) {
+    for (const entityId of updates.removed) {
+      delete state[entityId];
+    }
+  }
+
+  if (updates.changed) {
+    for (const entityId in updates.changed) {
+      let entityState = state[entityId];
+
+      if (!entityState) {
+        console.warn("Received state update for unknown entity", entityId);
+        continue;
+      }
+
+      entityState = { ...entityState };
+
+      const { "+": toAdd, "-": toRemove } = updates.changed[entityId];
+
+      const attributes =
+        toAdd?.a || toRemove?.a
+          ? { ...entityState.attributes }
+          : entityState.attributes;
+
+      if (toAdd) {
+        if (toAdd.s) {
+          entityState.state = toAdd.s;
+        }
+        if (toAdd.c) {
+          entityState.context = toAdd.c;
+        }
+        if (toAdd.lc) {
+          entityState.last_changed = toAdd.lc;
+          entityState.last_updated = toAdd.lc;
+        } else if (toAdd.lu) {
+          entityState.last_updated = toAdd.lu;
+        }
+
+        if (toAdd.a) {
+          Object.assign(attributes, toAdd.a);
+        }
+      }
+      if (toRemove) {
+        for (const key in toRemove.a) {
+          delete attributes[key];
+        }
+      }
+
+      entityState.attributes = attributes;
+      state[entityId] = entityState;
+    }
+  }
+
+  store.setState(state, true);
+}
+
+const subscribeUpdates = (conn: Connection, store: Store<HassEntities>) =>
+  conn.subscribeMessage<StatesUpdates>((ev) => processEvent(store, ev), {
+    type: "subscribe_entities",
+  });
+
+function legacyProcessEvent(
+  store: Store<HassEntities>,
+  event: StateChangedEvent
+) {
   const state = store.state;
   if (state === undefined) return;
 
@@ -18,7 +129,7 @@ function processEvent(store: Store<HassEntities>, event: StateChangedEvent) {
   }
 }
 
-async function fetchEntities(conn: Connection): Promise<HassEntities> {
+async function legacyFetchEntities(conn: Connection): Promise<HassEntities> {
   const states = await getStates(conn);
   const entities: HassEntities = {};
   for (let i = 0; i < states.length; i++) {
@@ -28,14 +139,16 @@ async function fetchEntities(conn: Connection): Promise<HassEntities> {
   return entities;
 }
 
-const subscribeUpdates = (conn: Connection, store: Store<HassEntities>) =>
+const legacySubscribeUpdates = (conn: Connection, store: Store<HassEntities>) =>
   conn.subscribeEvents<StateChangedEvent>(
     (ev) => processEvent(store, ev as StateChangedEvent),
     "state_changed"
   );
 
 export const entitiesColl = (conn: Connection) =>
-  getCollection(conn, "_ent", fetchEntities, subscribeUpdates);
+  atLeastHaVersion(conn.haVersion, 2022, 4, 0)
+    ? getCollection(conn, "_ent", () => Promise.resolve({}), subscribeUpdates)
+    : getCollection(conn, "_ent", legacyFetchEntities, legacySubscribeUpdates);
 
 export const subscribeEntities = (
   conn: Connection,

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -16,7 +16,7 @@ interface EntityState {
   /** attributes */
   a: { [key: string]: any };
   /** context */
-  c: Context;
+  c: Context | string;
   /** last_changed; if set, also applies to lu */
   lc: number;
   /** last_updated */
@@ -76,7 +76,11 @@ function processEvent(store: Store<HassEntities>, updates: StatesUpdates) {
           entityState.state = toAdd.s;
         }
         if (toAdd.c) {
-          entityState.context = { ...entityState.context, ...toAdd.c };
+          if (typeof toAdd.c === 'string') {
+            entityState.context = { ...entityState.context, "id": toAdd.c }
+          } else {
+            entityState.context = { ...entityState.context, ...toAdd.c }
+          }
         }
         if (toAdd.lc) {
           entityState.last_updated = entityState.last_changed = new Date(toAdd.lc * 1000).toISOString();

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -50,9 +50,14 @@ function processEvent(store: Store<HassEntities>, updates: StatesUpdates) {
         entity_id: entityId,
         state: newState.s,
         attributes: newState.a,
-        context: (typeof newState.c === 'string') ? {"id": newState.c, "parent_id": null, "user_id": null} : newState.c,
+        context:
+          typeof newState.c === "string"
+            ? { id: newState.c, parent_id: null, user_id: null }
+            : newState.c,
         last_changed: last_changed,
-        last_updated: newState.lu ? new Date(newState.lu * 1000).toISOString() : last_changed,
+        last_updated: newState.lu
+          ? new Date(newState.lu * 1000).toISOString()
+          : last_changed,
       };
     }
   }
@@ -81,20 +86,21 @@ function processEvent(store: Store<HassEntities>, updates: StatesUpdates) {
           entityState.state = toAdd.s;
         }
         if (toAdd.c) {
-          if (typeof toAdd.c === 'string') {
-            entityState.context = { ...entityState.context, "id": toAdd.c }
+          if (typeof toAdd.c === "string") {
+            entityState.context = { ...entityState.context, id: toAdd.c };
           } else {
-            entityState.context = { ...entityState.context, ...toAdd.c }
+            entityState.context = { ...entityState.context, ...toAdd.c };
           }
         }
         if (toAdd.lc) {
-          entityState.last_updated = entityState.last_changed = new Date(toAdd.lc * 1000).toISOString();
-        }
-        else if (toAdd.lu) {
+          entityState.last_updated = entityState.last_changed = new Date(
+            toAdd.lc * 1000
+          ).toISOString();
+        } else if (toAdd.lu) {
           entityState.last_updated = new Date(toAdd.lu * 1000).toISOString();
         }
         if (toAdd.a) {
-          entityState.attributes = { ...entityState.attributes, ...toAdd.a }
+          entityState.attributes = { ...entityState.attributes, ...toAdd.a };
         }
       }
       if (toRemove) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,13 +11,16 @@ export type MessageBase = {
   [key: string]: any;
 };
 
+export type Context = {
+  id: string;
+  user_id: string | null;
+  parent_id: string | null;
+};
+
 export type HassEventBase = {
   origin: string;
   time_fired: string;
-  context: {
-    id: string;
-    user_id: string;
-  };
+  context: Context;
 };
 
 export type HassEvent = HassEventBase & {
@@ -68,7 +71,7 @@ export type HassEntityBase = {
   last_changed: string;
   last_updated: string;
   attributes: HassEntityAttributeBase;
-  context: { id: string; user_id: string | null };
+  context: Context;
 };
 
 export type HassEntityAttributeBase = {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -41,3 +41,24 @@ export const debounce = <T extends (...args: any[]) => unknown>(
     }
   };
 };
+
+export const atLeastHaVersion = (
+  version: string,
+  major: number,
+  minor: number,
+  patch?: number
+): boolean => {
+  const [haMajor, haMinor, haPatch] = version.split(".", 3);
+
+  return (
+    Number(haMajor) > major ||
+    (Number(haMajor) === major &&
+      (patch === undefined
+        ? Number(haMinor) >= minor
+        : Number(haMinor) > minor)) ||
+    (patch !== undefined &&
+      Number(haMajor) === major &&
+      Number(haMinor) === minor &&
+      Number(haPatch) >= patch)
+  );
+};

--- a/test/entities.spec.ts
+++ b/test/entities.spec.ts
@@ -15,12 +15,13 @@ const MOCK_SWITCH = {
 
 const MOCK_ENTITIES = [MOCK_LIGHT, MOCK_SWITCH];
 
-describe("subscribeEntities", () => {
+describe("subscribeEntities legacy", () => {
   let conn: MockConnection;
   let awaitableEvent: AwaitableEvent;
 
   beforeEach(() => {
     conn = new MockConnection();
+    conn.haVersion = "2022.3.0";
     conn.mockResponse("get_states", MOCK_ENTITIES);
     awaitableEvent = new AwaitableEvent();
   });


### PR DESCRIPTION
Add support for `subscribe_entities`, the new and optimized way for listening to entity updates.

Core PR: https://github.com/home-assistant/core/pull/67891

Easiest way to test this PR:
- check out this repo
- update `lib/connection.ts` to set `DEBUG = true` on line 11
- `yarn run watch` (this will keep running)
- `npx http-server -o` which opens a browser
- Open `example.html`
- In browser console, `entities` will allow you to access latest entities.

![image](https://user-images.githubusercontent.com/1444314/157811588-a2810a6c-fa3b-40cb-940f-a6c2b6e7d43d.png)
