### PR TITLE
Fix race condition on fetch entities

### DIFF
--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -167,7 +167,7 @@ const legacySubscribeUpdates = (conn: Connection, store: Store<HassEntities>) =>
 
 export const entitiesColl = (conn: Connection) =>
   atLeastHaVersion(conn.haVersion, 2022, 4, 0)
-    ? getCollection(conn, "_ent", () => Promise.resolve({}), subscribeUpdates)
+    ? getCollection(conn, "_ent", undefined, subscribeUpdates)
     : getCollection(conn, "_ent", legacyFetchEntities, legacySubscribeUpdates);
 
 export const subscribeEntities = (


### PR DESCRIPTION
With the new way of doing fetchEntities, the current state and the delta's are received via a single websocket command. This solves any race condition that could occur between subscribing to updates and fetching the state. 

To work around the assumption in collections that it's always based around fetchState + subscribeUpdates the entities collection would return an empty object for fetchState.

However, this could end up causing a race condition for subscribers to the collection that only want the latest state (ie Lovelace generated dashboard). When the race occurred, Lovelace generated dashboard would think there were 0 entities.

This is now solved by making `fetchCollection` optional. If undefined, the state is only set by subscribeUpdates and the `refresh` option of the collection will raise an error when called.

**[Breaking change]** The entities collection can no longer be manually refreshed. This should not ever been necessary because it gets updates as soon as they happen.