### PR TITLE
Do not refresh collection on reconnect if no refresh command

### DIFF
--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -66,10 +66,9 @@ export const getCollection = <State>(
           unsubProm = subscribeUpdates(conn, store);
         }
 
-        // Fetch when connection re-established.
-        conn.addEventListener("ready", refreshSwallow);
-
         if (fetchCollection) {
+          // Fetch when connection re-established.
+          conn.addEventListener("ready", refreshSwallow);
           refreshSwallow();
         }
       }


### PR DESCRIPTION
If a collection does not have a separate fetchCollection command, do not listen for `ready` event to trigger a refresh.

Fixes failure to reconnect. 