### PR TITLE
Fix empty states being ignored

### DIFF
--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -91,7 +91,7 @@ function processEvent(store: Store<HassEntities>, updates: StatesUpdates) {
         : entityState.attributes;
 
       if (toAdd) {
-        if (toAdd.s) {
+        if (toAdd.s !== undefined) {
           entityState.state = toAdd.s;
         }
         if (toAdd.c) {


### PR DESCRIPTION
An empty state is a valid state (ie for an input_text)

Fixes https://github.com/home-assistant/core/issues/69990