### PR TITLE
fix: trim trailing slash in createLongLivedTokenAuth

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -226,7 +226,7 @@ export function createLongLivedTokenAuth(
   access_token: string
 ) {
   // Strip trailing slash.
-  if (hassUrl && hassUrl[hassUrl.length - 1] === "/") {
+  if (hassUrl[hassUrl.length - 1] === "/") {
     hassUrl = hassUrl.substr(0, hassUrl.length - 1);
   }
   

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -225,6 +225,11 @@ export function createLongLivedTokenAuth(
   hassUrl: string,
   access_token: string
 ) {
+  // Strip trailing slash.
+  if (hassUrl && hassUrl[hassUrl.length - 1] === "/") {
+    hassUrl = hassUrl.substr(0, hassUrl.length - 1);
+  }
+  
   return new Auth({
     hassUrl,
     clientId: null,


### PR DESCRIPTION
When creating `Auth` with `getAuth()`, it will trim the trailing slash from the hassUrl.

Calls to `createLongLivedTokenAuth()` would not do the same, sometimes resulting in the url containing `//` and causing it to error instead of connect