### PR TITLE
Clear state on teardown, make grace optional

### DIFF
--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -28,7 +28,7 @@ export const getCollection = <State>(
     conn: Connection,
     store: Store<State>
   ) => Promise<UnsubscribeFunc>,
-  unsubGrace = true
+  options: { unsubGrace: boolean } = { unsubGrace: true }
 ): Collection<State> => {
   if (conn[key]) {
     return conn[key];
@@ -151,7 +151,7 @@ export const getCollection = <State>(
         }
 
         if (!active) {
-          unsubGrace
+          options.unsubGrace
             ? scheduleTeardownUpdateSubscription()
             : teardownUpdateSubscription();
         }

--- a/lib/collection.ts
+++ b/lib/collection.ts
@@ -27,7 +27,8 @@ export const getCollection = <State>(
   subscribeUpdates?: (
     conn: Connection,
     store: Store<State>
-  ) => Promise<UnsubscribeFunc>
+  ) => Promise<UnsubscribeFunc>,
+  unsubGrace = true
 ): Collection<State> => {
   if (conn[key]) {
     return conn[key];
@@ -93,6 +94,7 @@ export const getCollection = <State>(
       unsubProm.then((unsub) => {
         unsub();
       });
+    store.clearState();
     conn.removeEventListener("ready", refresh);
     conn.removeEventListener("disconnected", handleDisconnect);
   };
@@ -149,7 +151,9 @@ export const getCollection = <State>(
         }
 
         if (!active) {
-          scheduleTeardownUpdateSubscription();
+          unsubGrace
+            ? scheduleTeardownUpdateSubscription()
+            : teardownUpdateSubscription();
         }
       };
     },

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -15,6 +15,7 @@ export type Store<State> = {
   state: State | undefined;
   action(action: Action<State>): BoundAction<State>;
   setState(update: Partial<State>, overwrite?: boolean): void;
+  clearState(): void;
   subscribe(listener: Listener<State>): UnsubscribeFunc;
 };
 
@@ -82,12 +83,16 @@ export const createStore = <State>(state?: State): Store<State> => {
      */
     setState,
 
+    clearState() {
+      state = undefined;
+    },
+
     /**
      * Register a listener function to be called whenever state is changed. Returns an `unsubscribe()` function.
      * @param {Function} listener	A function to call when state changes. Gets passed the new state.
      * @returns {Function} unsubscribe()
      */
-    subscribe(listener: Listener<State>) {
+    subscribe(listener: Listener<State>): UnsubscribeFunc {
       listeners.push(listener);
       return () => {
         unsubscribe(listener);


### PR DESCRIPTION
The state would always be kept in memory even when no one was using the collection anymore. This clears the state after the grace period (5 secs) passed and no one is subscribed.

Also adds an options to opt out of the grace period, this is useful in cases a timeout will not survive because it going to be unloaded for example.