### PR TITLE
Catch errors from extra event unsubscribe request

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -374,7 +374,14 @@ export class Connection {
             console.warn(
               `Received event for unknown subscription ${message.id}. Unsubscribing.`,
             );
-            this.sendMessagePromise(messages.unsubscribeEvents(message.id));
+            this.sendMessagePromise(
+              messages.unsubscribeEvents(message.id),
+            ).catch((err) => {
+              console.warn(
+                `Error unsubsribing from unknown subscription ${message.id}`,
+                err,
+              );
+            });
           }
           break;
 

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -377,10 +377,12 @@ export class Connection {
             this.sendMessagePromise(
               messages.unsubscribeEvents(message.id),
             ).catch((err) => {
-              console.warn(
-                `Error unsubsribing from unknown subscription ${message.id}`,
-                err,
-              );
+              if (DEBUG) {
+                console.warn(
+                  ` Error unsubsribing from unknown subscription ${message.id}`,
+                  err,
+                );
+              }
             });
           }
           break;


### PR DESCRIPTION
Prevent one source of "uncaught promise" errors on the console.

It appears the chain of steps causing it is:
After the client unsubscribes from an event, this library may receive an extra event message (I'm not sure why). That event message causes the library to send a second unsubscribe request (connection.ts, line 377). The server (which already unsubscribed due to the first request) may respond with an error of "subscription not found".  This PR catches that error so it doesn't bubble up to the console.