### PR TITLE
Recover from broken websocket connection

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -522,7 +522,7 @@ export class Connection {
     const pingLoop = () => {
       this.pingTimer.timerRef = setTimeout(() => {
         this.pingTimer.executing = true;
-        if (this.connected && this.closeRequested!) {
+        if (this.connected && !this.closeRequested) {
           try {
             this.ping();
           } catch (error) {

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -520,14 +520,15 @@ export class Connection {
     }
 
     const pingLoop = () => {
-      this.pingTimer.timerRef = setTimeout(() => {
+      this.pingTimer.timerRef = setTimeout(async () => {
         this.pingTimer.executing = true;
         if (this.connected && !this.closeRequested) {
           try {
-            this.ping();
+            await this.ping();
           } catch (error) {
-            if (error !== ERR_CONNECTION_TIMEOUT) {
-              this.reconnect();
+            if (error === ERR_CONNECTION_TIMEOUT) {
+              // Reconnect needs to be forced since no events are triggered when websocket is broken
+              this.reconnect(true);
             }
           }
         }

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -262,12 +262,12 @@ export class Connection {
 
   ping() {
     // create a promise that rejects in milliseconds
+    const pingRequest = this.sendMessagePromise(messages.ping());
     const timeout = new Promise<never>((_, reject) => {
       setTimeout(() => {
         reject(ERR_CONNECTION_TIMEOUT);
       }, this.pingTimeout);
     });
-    const pingRequest = this.sendMessagePromise(messages.ping());
     return Promise.race([pingRequest, timeout]);
   }
 
@@ -514,8 +514,11 @@ export class Connection {
   };
 
   private _scheduledPing() {
+    if (this.pingTimer.executing) {
+      return;
+    }
     // Reset timer before before scheduling a new one
-    if (this.pingTimer.timerRef && !this.pingTimer.executing) {
+    if (this.pingTimer.timerRef) {
       clearInterval(this.pingTimer.timerRef);
     }
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -4,3 +4,4 @@ export const ERR_CONNECTION_LOST = 3;
 export const ERR_HASS_HOST_REQUIRED = 4;
 export const ERR_INVALID_HTTPS_TO_HTTP = 5;
 export const ERR_INVALID_AUTH_CALLBACK = 6;
+export const ERR_CONNECTION_TIMEOUT = 7;


### PR DESCRIPTION
As described here: https://github.com/home-assistant/frontend/issues/17409 the HA frontend sometimes ends up with a broken web-socket connection to the backend. No error disconnect even/error is ever thrown. To work around this i have implemented a polling mechanism from the backend to the frontend. 
The frontend sends a ping message to the backend after it hasn't received any messages for 60 seconds with a 5 second timeout and forces the socket to close if no response is recieved.