### PR TITLE
Extend services type

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -102,10 +102,21 @@ export type HassService = {
   target?: {} | null;
   fields: {
     [field_name: string]: {
+      example?: string | boolean | number;
+      default?: unknown;
+      required?: boolean;
+      advanced?: boolean;
+      selector?: {};
+      filter?:
+        | {
+            attribute?: Record<string, string>;
+          }
+        | {
+            supported_features?: Record<string, string>;
+          };
+      // Custom integrations don't use translations and still have name/description
       name?: string;
       description: string;
-      example: string | boolean | number;
-      selector?: {};
     };
   };
   response?: { optional: boolean };


### PR DESCRIPTION
Update the type to match the latest allowed service fields in Home Assistant.

Ref: https://github.com/home-assistant/core/blob/dev/script/hassfest/services.py#L28