### PR TITLE
Add radius to core configuration

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -41,6 +41,7 @@ export type HassConfig = {
   latitude: number;
   longitude: number;
   elevation: number;
+  radius: number;
   unit_system: {
     length: string;
     mass: string;


### PR DESCRIPTION
Add `radius` to the core configuration; goes with:

<https://github.com/home-assistant/core/pull/119385>

Needed for:

<https://github.com/home-assistant/frontend/pull/21096>
