### PR TITLE
export store to use createCollection() in ts

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,6 +12,7 @@ export * from "./errors.js";
 export * from "./socket.js";
 export * from "./types.js";
 export * from "./commands.js";
+export * from "./store.js";
 
 export async function createConnection(options?: Partial<ConnectionOptions>) {
   const connOptions: ConnectionOptions = {


### PR DESCRIPTION
Fixes an issue where we couldn't use createColection in typescript properly as it's not possible to import the `Store` type.

As it's needed to import it from `home-assistant-js-webocket/dist/store`
TS is complaining
> TS2307: Cannot find module home-assistant-js-websocket/ dist/ store or its corresponding type declarations.