### PR TITLE
Ignore stored tokens for other URLs

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -285,7 +285,8 @@ export async function getAuth(options: getAuthOptions = {}): Promise<Auth> {
     data = await options.loadTokens();
   }
 
-  if (data) {
+  // If the token is for another url, ignore it
+  if (data && (hassUrl === undefined || data.hassUrl === hassUrl)) {
     return new Auth(data, options.saveTokens);
   }
 


### PR DESCRIPTION
If the stored token would be for another `hassUrl` than we would try to connect to, it would connect to the `hassUrl` in the stored token.

This guards for that.