### PR TITLE
Add optional pre check to subscribe message

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -301,7 +301,10 @@ export class Connection {
   async subscribeMessage<Result>(
     callback: (result: Result) => void,
     subscribeMessage: MessageBase,
-    options?: { resubscribe?: boolean; preCheck?: () => Promise<boolean> },
+    options?: {
+      resubscribe?: boolean;
+      preCheck?: () => boolean | Promise<boolean>;
+    },
   ): Promise<SubscriptionUnsubscribe> {
     if (this._queuedMessages) {
       await new Promise((resolve, reject) => {


### PR DESCRIPTION
This allows us to pass a pre check function to be able to wait for core to setup an integration for example. This is needed here because subscriptions are automatically re-created when Home Assistant restarts, and we can not be sure at that time if all integrations that has a subscription before restart are set up already.