### PR TITLE
perf: avoid copying the full entity map on updates

### DIFF
--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -44,8 +44,13 @@ interface StatesUpdates {
   c: Record<string, EntityDiff>;
 }
 
-function processEvent(store: Store<HassEntities>, updates: StatesUpdates) {
-  const state = { ...store.state };
+export function processEvent(
+  store: Store<HassEntities>,
+  updates: StatesUpdates,
+) {
+  // Entity updates are incremental. Reuse the cached map instead of copying
+  // every entity before applying each update.
+  const state = store.state || {};
 
   if (updates.a) {
     for (const entityId in updates.a) {

--- a/test/entities.spec.ts
+++ b/test/entities.spec.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 
-import { subscribeEntities } from "../dist/entities.js";
+import { processEvent, subscribeEntities } from "../dist/entities.js";
+import { createStore } from "../dist/store.js";
 import { MockConnection, AwaitableEvent } from "./util.js";
 
 const MOCK_LIGHT = {
@@ -118,6 +119,76 @@ describe("subscribeEntities legacy", () => {
 
     assert.deepEqual(entities, {
       [MOCK_SWITCH.entity_id]: MOCK_SWITCH,
+    });
+  });
+});
+
+describe("subscribeEntities incremental updates", () => {
+  it("preserves unchanged entities while applying adds, changes, and removals", () => {
+    const unchanged = {
+      entity_id: "sensor.unchanged",
+      state: "1",
+      attributes: { unit_of_measurement: "kW" },
+      context: { id: "unchanged" },
+      last_changed: "2026-01-01T00:00:00.000Z",
+      last_updated: "2026-01-01T00:00:00.000Z",
+    };
+    const changed = {
+      entity_id: "light.kitchen",
+      state: "off",
+      attributes: { brightness: 10 },
+      context: { id: "changed" },
+      last_changed: "2026-01-01T00:00:00.000Z",
+      last_updated: "2026-01-01T00:00:00.000Z",
+    };
+    const removed = {
+      entity_id: "switch.garage",
+      state: "on",
+      attributes: {},
+      context: { id: "removed" },
+      last_changed: "2026-01-01T00:00:00.000Z",
+      last_updated: "2026-01-01T00:00:00.000Z",
+    };
+    const store = createStore({
+      [unchanged.entity_id]: unchanged,
+      [changed.entity_id]: changed,
+      [removed.entity_id]: removed,
+    });
+
+    processEvent(store, {
+      a: {
+        "binary_sensor.new": {
+          s: "on",
+          a: {},
+          c: "new",
+          lc: 1767225600,
+          lu: 1767225600,
+        },
+      },
+      r: [removed.entity_id],
+      c: {
+        [changed.entity_id]: {
+          "+": { s: "on", a: { brightness: 100 } },
+          "-": { a: ["brightness"] },
+        },
+      },
+    });
+
+    assert.deepStrictEqual(store.state, {
+      [unchanged.entity_id]: unchanged,
+      [changed.entity_id]: {
+        ...changed,
+        state: "on",
+        attributes: {},
+      },
+      "binary_sensor.new": {
+        entity_id: "binary_sensor.new",
+        state: "on",
+        attributes: {},
+        context: { id: "new", parent_id: null, user_id: null },
+        last_changed: "2026-01-01T00:00:00.000Z",
+        last_updated: "2026-01-01T00:00:00.000Z",
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary

This is a complementary fix to [node-red-contrib-home-assistant-websocket#2011](https://github.com/zachowj/node-red-contrib-home-assistant-websocket/pull/2011).

That PR reduces repeated deep-cloning in the Node-RED add-on. This change addresses the earlier stage of the same update path: `processEvent` currently creates a shallow copy of the complete entity map for every incremental `subscribe_entities` update.

The update payload is incremental, and the existing code already applies additions, changes, and removals to that map before publishing it. Reusing the cached map avoids allocating and enumerating the complete entity collection on every update while preserving the resulting entity contents.

The change is intentionally limited to the entity-update hot path. It does not alter the update protocol, entity fields, subscription behaviour, or nested entity/state copying.

## Testing

### Automated

The added regression test applies an addition, a state/attribute change, and a removal in one update. It verifies that the changed result still contains the unchanged entity, the updated entity, and the new entity, with the removed entity absent.

Run:

```sh
yarn test
```

### Manual compatibility checks

When testing this together with Node-RED PR #2011:

1. Start Node-RED with a representative Home Assistant instance and record its version, Node.js version, package versions, and baseline CPU over a fixed interval.
2. Exercise a connection receiving frequent `subscribe_entities` updates. Confirm that additions, removals, state changes, attribute changes, reconnects, and Home Assistant restarts are all observed.
3. Verify representative Node-RED nodes that read states still behave correctly, including Current State, Get Entities, API/template actions, Events State, Trigger State, Wait Until, and Tag/Zone handling.
4. Confirm that callers do not mutate the object returned by the websocket subscription. The optimisation reuses the cached top-level map, so consumers must treat subscribed state as read-only.
5. Apply the Node-RED #2011 changes and repeat the same workload. Compare CPU, message rate, entity counts, state values, and reconnect behaviour against the baseline.
6. Run the workload long enough to cover several thousand incremental updates, then restart Node-RED and Home Assistant independently and verify clean recovery.

The expected result is lower allocation/CPU pressure with identical entity contents and lifecycle behaviour. A regression in entity counts, stale state, removals, reconnects, or consumer mutation should block adoption.
